### PR TITLE
fix(lint): post-merge cleanup — visible warnings, A1 preservation, helper consolidation

### DIFF
--- a/src/lint.ts
+++ b/src/lint.ts
@@ -39,15 +39,35 @@ const LINT_NOTE_PREFIX = "[Lint] ";
 const SLUG_COLLISION_LINT_NOTE_PREFIX = `${LINT_NOTE_PREFIX}Slug collision:`;
 const SOURCE_OVERWRITE_LINT_NOTE_PREFIX = `${LINT_NOTE_PREFIX}Source value`;
 
-/** Module-level cache for Drive icon info, shared across lint checks to avoid
- *  redundant Drive API calls and keep Drive URL classification consistent. */
-const driveIconInfoCache = new Map<string, DriveIconInfo>();
+// --- Types -----------------------------------------------------------------
 
 type DriveIconInfo = {
   slug: string | null;
   isSvg: boolean;
   svgContent: string | null;
   errorMessage?: string;
+};
+
+type LintSeverity = "error" | "warning" | "advisory";
+
+// --- Constants --------------------------------------------------------------
+
+/** Module-level cache for Drive icon info, shared across lint checks to avoid
+ *  redundant Drive API calls and keep Drive URL classification consistent. */
+const driveIconInfoCache = new Map<string, DriveIconInfo>();
+
+/**
+ * Single source of truth for severity → visual style.
+ * `background`/`fontColor` of `null` mean "leave that property unchanged".
+ * Shared by all four lint-note writers so they can never drift apart.
+ */
+const LINT_SEVERITY_STYLE: Record<
+  LintSeverity,
+  { background: string | null; fontColor: string | null }
+> = {
+  error: { background: LINT_ERROR_BG, fontColor: "red" },
+  warning: { background: LINT_WARNING_BG, fontColor: "orange" },
+  advisory: { background: LINT_ADVISORY_BG, fontColor: null },
 };
 function clearRangeBackgroundIfMatches(
   range: GoogleAppsScript.Spreadsheet.Range,
@@ -232,22 +252,7 @@ function clearRangeLintNotesWithPrefixes(
   }
 }
 
-type LintSeverity = "error" | "warning" | "advisory";
 
-/**
- * Single source of truth for severity → visual style.
- * `background`/`fontColor` of `null` mean "leave that property unchanged".
- * Shared by setLintNote and setLintNotePreserveBackground so the two writers
- * can never drift apart.
- */
-const LINT_SEVERITY_STYLE: Record<
-  LintSeverity,
-  { background: string | null; fontColor: string | null }
-> = {
-  error: { background: LINT_ERROR_BG, fontColor: "red" },
-  warning: { background: LINT_WARNING_BG, fontColor: "orange" },
-  advisory: { background: LINT_ADVISORY_BG, fontColor: null },
-};
 
 /**
  * Standardized lint note writer. Sets a [Lint]-prefixed note on a cell and applies
@@ -267,8 +272,8 @@ function setLintNote(
   cell.setNote(`${LINT_NOTE_PREFIX}${message}`);
 
   const style = LINT_SEVERITY_STYLE[severity];
-  if (style.background) cell.setBackground(style.background);
-  if (style.fontColor) cell.setFontColor(style.fontColor);
+  if (style.background !== null) cell.setBackground(style.background);
+  if (style.fontColor !== null) cell.setFontColor(style.fontColor);
 }
 
 /**
@@ -309,21 +314,21 @@ function appendLintNote(
       // already at a higher visual severity. LINT_CRITICAL_BG cells use white text,
       // so skip fontColor too to keep them readable.
       if (currentBg !== LINT_CRITICAL_BG) {
-        cell.setBackground(LINT_ERROR_BG);
-        cell.setFontColor("red");
+        cell.setBackground(LINT_SEVERITY_STYLE.error.background!);
+        cell.setFontColor(LINT_SEVERITY_STYLE.error.fontColor!);
       }
       break;
     case "warning":
       // Only set warning styling if not already at error level
       if (!isAlreadyError) {
-        cell.setBackground(LINT_WARNING_BG);
-        cell.setFontColor("orange");
+        cell.setBackground(LINT_SEVERITY_STYLE.warning.background!);
+        cell.setFontColor(LINT_SEVERITY_STYLE.warning.fontColor!);
       }
       break;
     case "advisory":
       // Only set advisory styling if no higher severity is present
       if (!isAlreadyError && !isAlreadyWarning) {
-        cell.setBackground(LINT_ADVISORY_BG);
+        cell.setBackground(LINT_SEVERITY_STYLE.advisory.background!);
       }
       break;
   }
@@ -369,7 +374,7 @@ function setLintNotePreserveBackground(
 
   // Font color only — background is intentionally left untouched.
   const { fontColor } = LINT_SEVERITY_STYLE[severity];
-  if (fontColor) cell.setFontColor(fontColor);
+  if (fontColor !== null) cell.setFontColor(fontColor);
 }
 
 /**
@@ -403,11 +408,11 @@ function appendLintNotePreserveBackground(
 
   switch (severity) {
     case "error":
-      cell.setFontColor("red");
+      cell.setFontColor(LINT_SEVERITY_STYLE.error.fontColor!);
       break;
     case "warning":
       if (!isAlreadyError) {
-        cell.setFontColor("orange");
+        cell.setFontColor(LINT_SEVERITY_STYLE.warning.fontColor!);
       }
       break;
     case "advisory":
@@ -693,16 +698,19 @@ function validateAppliesColumn(): void {
 
   if (appliesColZeroBased === -1) {
     // The Applies header was removed or renamed. We've already cleared
-    // Applies-specific notes above. Intentionally avoid blanket-clearing the
-    // sheet here because earlier lint phases may have already annotated other
-    // columns, and those findings must be preserved.
+    // Applies-specific notes above (within the existing lastCol range).
+    // Also clear column D specifically — when lastCol < 4 the header-row
+    // clear above doesn't reach it, so a stale warning would accumulate.
+    const appliesExpectedCol = 4;
+    const headerCell = categoriesSheet.getRange(1, appliesExpectedCol);
+    clearRangeLintNotesWithPrefixes(headerCell, [
+      `${LINT_NOTE_PREFIX}No "Applies" header found.`,
+    ]);
     // Place the warning at the conventional Applies column position (column D)
     // rather than A1 (reserved for the Primary Language annotation) or
     // `lastCol + 1`, which lands in an off-screen empty column on wide sheets.
     // Column D is where Applies normally lives, so the warning stays visible
     // even when the header was renamed or removed.
-    const appliesExpectedCol = 4;
-    const headerCell = categoriesSheet.getRange(1, appliesExpectedCol);
     appendLintNote(
       headerCell,
       'No "Applies" header found. The builder resolves this column by header name and may auto-create it, seeding the first category with "track, observation".',

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -132,22 +132,22 @@ function clearRangeNotesWithPrefix(
   }
 }
 
-function clearRangeLintNoteLinesWithPrefix(
+function clearRangeLintNotesWithPrefix(
   range: GoogleAppsScript.Spreadsheet.Range,
   prefix: string,
   fontColorsToClear: string[] = LINT_WARNING_FONT_COLORS,
   backgroundColorsToClear: string[] = LINT_WARNING_BACKGROUND_COLORS,
 ): void {
   if (!prefix) return; // Empty prefix would match all lines — treat as no-op.
-  clearRangeLintNoteLinesWithPrefixes(range, [prefix], fontColorsToClear, backgroundColorsToClear);
+  clearRangeLintNotesWithPrefixes(range, [prefix], fontColorsToClear, backgroundColorsToClear);
 }
 
 /**
- * Batch version of clearRangeLintNoteLinesWithPrefix.
+ * Batch version of clearRangeLintNotesWithPrefix.
  * Removes all lines starting with any of the given prefixes from notes in the range.
  * Reads notes/fontColors/backgrounds only once regardless of how many prefixes are provided.
  */
-function clearRangeLintNoteLinesWithPrefixes(
+function clearRangeLintNotesWithPrefixes(
   range: GoogleAppsScript.Spreadsheet.Range,
   prefixes: string[],
   fontColorsToClear: string[] = LINT_WARNING_FONT_COLORS,
@@ -342,13 +342,13 @@ function clearLintArtifacts(
 
   clearRangeBackgroundIfMatches(range, LINT_WARNING_BACKGROUND_COLORS);
   clearRangeFontColorIfMatches(range, LINT_WARNING_FONT_COLORS);
-  clearRangeLintNoteLinesWithPrefix(range, LINT_NOTE_PREFIX);
+  clearRangeLintNotesWithPrefix(range, LINT_NOTE_PREFIX);
 }
 
 function clearSourceOverwriteLintArtifacts(
   range: GoogleAppsScript.Spreadsheet.Range,
 ): void {
-  clearRangeLintNoteLinesWithPrefix(
+  clearRangeLintNotesWithPrefix(
     range,
     SOURCE_OVERWRITE_LINT_NOTE_PREFIX,
     LINT_WARNING_FONT_COLORS_WITHOUT_WHITE,
@@ -591,7 +591,7 @@ function checkSlugCollisions(
   // checkForDuplicates() remain intact while stale slug warnings are refreshed.
   // This path preserves user-managed category colors and font choices, so it
   // only strips the note lines and leaves visual formatting untouched.
-  clearRangeLintNoteLinesWithPrefix(
+  clearRangeLintNotesWithPrefix(
     nameRange,
     SLUG_COLLISION_LINT_NOTE_PREFIX,
     [],
@@ -655,7 +655,7 @@ function validateAppliesColumn(): void {
   const lastCol = categoriesSheet.getLastColumn();
   if (lastCol > 0) {
     const headerRowRange = categoriesSheet.getRange(1, 1, 1, lastCol);
-    clearRangeLintNoteLinesWithPrefixes(
+    clearRangeLintNotesWithPrefixes(
       headerRowRange,
       [
         `${LINT_NOTE_PREFIX}No "Applies" header found.`,
@@ -666,7 +666,7 @@ function validateAppliesColumn(): void {
 
     if (lastRow > 1) {
       const bodyRange = categoriesSheet.getRange(2, 1, lastRow - 1, lastCol);
-      clearRangeLintNoteLinesWithPrefixes(
+      clearRangeLintNotesWithPrefixes(
         bodyRange,
         [
           `${LINT_NOTE_PREFIX}Unrecognized Applies token(s):`,
@@ -726,7 +726,7 @@ function validateAppliesColumn(): void {
   // Also clear header cell artifacts (Applies-specific notes only, to avoid
   // wiping higher-priority annotations on the same cell, e.g. A1 language error)
   const headerCell = categoriesSheet.getRange(1, appliesColIndex);
-  clearRangeLintNoteLinesWithPrefixes(
+  clearRangeLintNotesWithPrefixes(
     headerCell,
     [
       `${LINT_NOTE_PREFIX}No "Applies" header found.`,
@@ -1170,7 +1170,7 @@ function checkForDuplicates(
     1,
   );
   if (preserveBackground) {
-    clearRangeLintNoteLinesWithPrefix(
+    clearRangeLintNotesWithPrefix(
       range,
       LINT_NOTE_PREFIX,
       LINT_WARNING_FONT_COLORS,
@@ -1178,7 +1178,7 @@ function checkForDuplicates(
     );
     clearRangeFontColorIfMatches(range, LINT_WARNING_FONT_COLORS);
   } else {
-    clearRangeLintNoteLinesWithPrefix(range, LINT_NOTE_PREFIX);
+    clearRangeLintNotesWithPrefix(range, LINT_NOTE_PREFIX);
     clearRangeBackgroundIfMatches(range, LINT_WARNING_BACKGROUND_COLORS);
     clearRangeFontColorIfMatches(range, LINT_WARNING_FONT_COLORS);
   }
@@ -1248,7 +1248,7 @@ function checkUnreferencedDetails(): void {
     if (detailsLastRow <= 1) return; // No details to check
 
     const detailRange = detailsSheet.getRange(2, 1, detailsLastRow - 1, 1);
-    clearRangeLintNoteLinesWithPrefix(
+    clearRangeLintNotesWithPrefix(
       detailRange,
       `${LINT_NOTE_PREFIX}Detail `,
     );
@@ -1423,7 +1423,7 @@ function checkDuplicateTranslationSlugs(): void {
 
       // Clear only duplicate-slug lint notes from prior runs, preserving
       // option-count mismatch backgrounds/fonts set by validateSheetConsistency().
-      clearRangeLintNoteLinesWithPrefix(
+      clearRangeLintNotesWithPrefix(
         sheet.getRange(2, 4, lastRow - 1, lastCol - 3),
         `${LINT_NOTE_PREFIX}Duplicate translation slug`,
       );
@@ -1601,7 +1601,7 @@ function lintSheet(
         }
         clearRangeFontColorIfMatches(colRange, LINT_WARNING_FONT_COLORS);
         // Clear stale [Lint] notes so re-linting produces a clean result
-        clearRangeLintNoteLinesWithPrefix(colRange, LINT_NOTE_PREFIX);
+        clearRangeLintNotesWithPrefix(colRange, LINT_NOTE_PREFIX);
       }
     }
 
@@ -3100,7 +3100,7 @@ function validateSheetConsistency(
       // Clear any stale row-count mismatch note from a prior lint run to prevent
       // duplicate accumulation (the background/font clear above only covers dataRange,
       // rows 2+, so A1 is excluded and the note would persist indefinitely).
-      clearRangeLintNoteLinesWithPrefix(
+      clearRangeLintNotesWithPrefix(
         translationSheet.getRange(1, 1),
         `${LINT_NOTE_PREFIX}Row count mismatch:`,
       );
@@ -4662,6 +4662,13 @@ function collectStrictLintMetrics(): {
     Array<{ sheetName: string; column: number; header: string }>
   >;
 } {
+  // Perf note (#29/#30): getSpreadsheetData() is invoked exactly once per lint
+  // run — only here, and lintAllSheets() calls collectStrictLintMetrics() once.
+  // A per-execution cache would therefore be dead code. The remaining overlap is
+  // between this single full-workbook snapshot and the per-sheet getRange() reads
+  // each lint check performs; eliminating that would require routing every check
+  // through a shared in-memory snapshot, i.e. a lint-engine redesign that is
+  // explicitly out of scope. The single read is acceptable for a manual lint.
   const data = getSpreadsheetData();
   const categories = buildLintCategorySummaries(data);
   const fields = buildLintFieldSummaries(data);

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -232,6 +232,23 @@ function clearRangeLintNoteLinesWithPrefixes(
   }
 }
 
+type LintSeverity = "error" | "warning" | "advisory";
+
+/**
+ * Single source of truth for severity → visual style.
+ * `background`/`fontColor` of `null` mean "leave that property unchanged".
+ * Shared by setLintNote and setLintNotePreserveBackground so the two writers
+ * can never drift apart.
+ */
+const LINT_SEVERITY_STYLE: Record<
+  LintSeverity,
+  { background: string | null; fontColor: string | null }
+> = {
+  error: { background: LINT_ERROR_BG, fontColor: "red" },
+  warning: { background: LINT_WARNING_BG, fontColor: "orange" },
+  advisory: { background: LINT_ADVISORY_BG, fontColor: null },
+};
+
 /**
  * Standardized lint note writer. Sets a [Lint]-prefixed note on a cell and applies
  * severity-appropriate background and font colors so that cleanup and UI behavior
@@ -245,23 +262,13 @@ function clearRangeLintNoteLinesWithPrefixes(
 function setLintNote(
   cell: GoogleAppsScript.Spreadsheet.Range,
   message: string,
-  severity: "error" | "warning" | "advisory",
+  severity: LintSeverity,
 ): void {
   cell.setNote(`${LINT_NOTE_PREFIX}${message}`);
 
-  switch (severity) {
-    case "error":
-      cell.setBackground(LINT_ERROR_BG);
-      cell.setFontColor("red");
-      break;
-    case "warning":
-      cell.setBackground(LINT_WARNING_BG);
-      cell.setFontColor("orange");
-      break;
-    case "advisory":
-      cell.setBackground(LINT_ADVISORY_BG);
-      break;
-  }
+  const style = LINT_SEVERITY_STYLE[severity];
+  if (style.background) cell.setBackground(style.background);
+  if (style.fontColor) cell.setFontColor(style.fontColor);
 }
 
 /**
@@ -275,7 +282,7 @@ function setLintNote(
 function appendLintNote(
   cell: GoogleAppsScript.Spreadsheet.Range,
   message: string,
-  severity: "error" | "warning" | "advisory",
+  severity: LintSeverity,
 ): void {
   const existingNote = cell.getNote() || "";
   const newMessage = `${LINT_NOTE_PREFIX}${message}`;
@@ -356,20 +363,13 @@ function clearSourceOverwriteLintArtifacts(
 function setLintNotePreserveBackground(
   cell: GoogleAppsScript.Spreadsheet.Range,
   message: string,
-  severity: "error" | "warning" | "advisory",
+  severity: LintSeverity,
 ): void {
   cell.setNote(`${LINT_NOTE_PREFIX}${message}`);
 
-  switch (severity) {
-    case "error":
-      cell.setFontColor("red");
-      break;
-    case "warning":
-      cell.setFontColor("orange");
-      break;
-    case "advisory":
-      break;
-  }
+  // Font color only — background is intentionally left untouched.
+  const { fontColor } = LINT_SEVERITY_STYLE[severity];
+  if (fontColor) cell.setFontColor(fontColor);
 }
 
 /**
@@ -380,7 +380,7 @@ function setLintNotePreserveBackground(
 function appendLintNotePreserveBackground(
   cell: GoogleAppsScript.Spreadsheet.Range,
   message: string,
-  severity: "error" | "warning" | "advisory",
+  severity: LintSeverity,
 ): void {
   const existingNote = cell.getNote() || "";
   const newMessage = `${LINT_NOTE_PREFIX}${message}`;
@@ -696,9 +696,12 @@ function validateAppliesColumn(): void {
     // Applies-specific notes above. Intentionally avoid blanket-clearing the
     // sheet here because earlier lint phases may have already annotated other
     // columns, and those findings must be preserved.
-    // Place the warning at the expected Applies column position (column D)
-    // rather than A1, which is reserved for the Primary Language annotation.
-    const appliesExpectedCol = Math.max(lastCol + 1, 4);
+    // Place the warning at the conventional Applies column position (column D)
+    // rather than A1 (reserved for the Primary Language annotation) or
+    // `lastCol + 1`, which lands in an off-screen empty column on wide sheets.
+    // Column D is where Applies normally lives, so the warning stays visible
+    // even when the header was renamed or removed.
+    const appliesExpectedCol = 4;
     const headerCell = categoriesSheet.getRange(1, appliesExpectedCol);
     appendLintNote(
       headerCell,
@@ -787,10 +790,13 @@ function validateAppliesColumn(): void {
     // Mirror builder's parseTokens() which ONLY splits by comma — semicolons,
     // newlines, and other delimiters are NOT recognized in the Applies column
     // (unlike the Fields column which uses normalizeFieldTokens with broader parsing).
-    const tokens = rawValue
+    // Keep the original-cased tokens for display in lint messages while matching
+    // case-insensitively, so warnings echo exactly what the user typed.
+    const rawTokens = rawValue
       .split(",")
-      .map((t) => t.trim().toLowerCase())
+      .map((t) => t.trim())
       .filter(Boolean);
+    const tokens = rawTokens.map((t) => t.toLowerCase());
 
     // Warn if the raw value contains non-comma delimiters that the builder ignores.
     // This catches cases like "track; observation" where the semicolon causes the
@@ -812,8 +818,11 @@ function validateAppliesColumn(): void {
         return "";
       })
       .filter(Boolean);
-    const invalidTokens = tokens.filter((token) => {
-      return !token.startsWith("o") && !token.startsWith("t");
+    // Report invalid tokens using their original casing while matching on the
+    // lowercased form, so the warning shows exactly what the user entered.
+    const invalidTokens = rawTokens.filter((token) => {
+      const lower = token.toLowerCase();
+      return !lower.startsWith("o") && !lower.startsWith("t");
     });
 
     if (invalidTokens.length > 0) {
@@ -4763,7 +4772,10 @@ function checkTotalEntityCounts(metrics: {
     const cell = categoriesSheet
       ? categoriesSheet.getRange(1, 1)
       : spreadsheet.getActiveSheet().getRange(1, 1);
-    appendLintNote(
+    // A1 doubles as the primary-language cell (see validatePrimaryLanguageInA1).
+    // Use the preserve-background variant so this advisory does not overwrite any
+    // user-set A1 background; it still signals the error via red font + note.
+    appendLintNotePreserveBackground(
       cell,
       `Total entity count (${totalCount}) exceeds 10,000 limit. Categories: ${metrics.categoryCount}, Details: ${metrics.fieldCount}, Icons: ${metrics.iconCount}, Options: ${metrics.optionCount}, Translations: ${metrics.translationEntryCount}. This will fail strict validation.`,
       "error",

--- a/src/test/testLint.ts
+++ b/src/test/testLint.ts
@@ -652,10 +652,13 @@ function testAppliesHeaderDetectionParity(): boolean {
       (lintCalls) => {
         validateAppliesColumn();
 
+        // The missing-header warning is placed on the conventional Applies
+        // column (column D / col 4) so it stays visible, rather than A1
+        // (reserved for the primary-language note) or an off-screen column.
         const missingHeaderWarnings = lintCalls.filter(
           (call) =>
             call.row === 1 &&
-            call.col === 1 &&
+            call.col === 4 &&
             call.severity === "warning" &&
             call.message.includes('No "Applies" header found'),
         );
@@ -1346,10 +1349,13 @@ function testAppliesMissingHeaderPreservesExistingBodyAnnotations(): boolean {
 
         validateAppliesColumn();
 
+        // The missing-header warning is placed on the conventional Applies
+        // column (column D / col 4) so it stays visible, rather than A1
+        // (reserved for the primary-language note) or an off-screen column.
         const missingHeaderWarnings = lintCalls.filter(
           (call) =>
             call.row === 1 &&
-            call.col === 1 &&
+            call.col === 4 &&
             call.severity === "warning" &&
             call.message.includes('No "Applies" header found'),
         );

--- a/src/test/testLint.ts
+++ b/src/test/testLint.ts
@@ -11,8 +11,9 @@
  * ## Mock Framework
  *
  * The mock framework below simulates the GAS Spreadsheet API so lint functions can run
- * without a real spreadsheet. It replaces `SpreadsheetApp`, `setLintNote`, and
- * `appendLintNote` on `globalThis` for the duration of each test callback.
+ * without a real spreadsheet. It replaces `SpreadsheetApp`, `setLintNote`,
+ * `appendLintNote`, and `appendLintNotePreserveBackground` on `globalThis` for the
+ * duration of each test callback.
  *
  * ### Color Constant Synchronization
  *
@@ -330,8 +331,9 @@ function getMockCellState(target: any): MockCellState {
  * @param callback - Receives an array of `MockLintCall` objects that accumulate during
  *   the lint execution. Assert against these to verify lint behavior.
  *
- * During execution, `SpreadsheetApp`, `setLintNote`, and `appendLintNote` are replaced
- * on `globalThis`. Originals are restored in a `finally` block.
+ * During execution, `SpreadsheetApp`, `setLintNote`, `appendLintNote`, and
+ * `appendLintNotePreserveBackground` are replaced on `globalThis`. Originals
+ * are restored in a `finally` block.
  */
 function runWithMockedLintSpreadsheet(
   sheets: Record<string, any[][]>,
@@ -341,6 +343,7 @@ function runWithMockedLintSpreadsheet(
   const originalSpreadsheetApp = globalScope.SpreadsheetApp;
   const originalSetLintNote = globalScope.setLintNote;
   const originalAppendLintNote = globalScope.appendLintNote;
+  const originalAppendLintNotePreserveBackground = globalScope.appendLintNotePreserveBackground;
   const lintCalls: MockLintCall[] = [];
   const sheetStates = new Map<
     string,
@@ -547,6 +550,31 @@ function runWithMockedLintSpreadsheet(
     appendMockLintStyle(cellState, severity);
     lintCalls.push({ row: cell.row, col: cell.col, message, severity });
   };
+  globalScope.appendLintNotePreserveBackground = (
+    cell: any,
+    message: string,
+    severity: "error" | "warning" | "advisory",
+  ): void => {
+    const cellState = getMockCellState(cell);
+    appendMockLintNote(cellState, message);
+    // Preserve-background variant: only set font color, skip background.
+    // Mirrors production appendLintNotePreserveBackground escalation logic.
+    const currentFont = (cellState.fontColor || "").toUpperCase();
+    const isAlreadyError = currentFont === "RED";
+    switch (severity) {
+      case "error":
+        cellState.fontColor = LINT_WARNING_FONT_COLORS[0]; // "red"
+        break;
+      case "warning":
+        if (!isAlreadyError) {
+          cellState.fontColor = LINT_WARNING_FONT_COLORS[1]; // "orange"
+        }
+        break;
+      case "advisory":
+        break;
+    }
+    lintCalls.push({ row: cell.row, col: cell.col, message, severity });
+  };
 
   try {
     callback(lintCalls);
@@ -554,6 +582,7 @@ function runWithMockedLintSpreadsheet(
     globalScope.SpreadsheetApp = originalSpreadsheetApp;
     globalScope.setLintNote = originalSetLintNote;
     globalScope.appendLintNote = originalAppendLintNote;
+    globalScope.appendLintNotePreserveBackground = originalAppendLintNotePreserveBackground;
   }
 }
 

--- a/src/test/testLint.ts
+++ b/src/test/testLint.ts
@@ -747,7 +747,7 @@ function testLintAppendAndClearSemantics(): boolean {
         emptyPrefixCell.setNote("[Lint] keep me\nmanual line");
         emptyPrefixCell.setBackground(LINT_WARNING_BACKGROUND_COLORS[3]);
         emptyPrefixCell.setFontColor(LINT_WARNING_FONT_COLORS[1]);
-        clearRangeLintNoteLinesWithPrefix(emptyPrefixCell, "");
+        clearRangeLintNotesWithPrefix(emptyPrefixCell, "");
         if (emptyPrefixCell.getNote() !== "[Lint] keep me\nmanual line") {
           throw new Error(
             `Empty prefix should not clear lint note lines, got "${emptyPrefixCell.getNote()}"`,


### PR DESCRIPTION
Closes #30. Closes #29.

Post-merge cleanup of `src/lint.ts` from the PR #28 review. Behavior-preserving except for three intentional, well-scoped fixes.

## Fixes (#30)

1. **A1 background no longer clobbered** — `checkTotalEntityCounts` wrote the >10k-entity advisory to `Categories!A1` (which doubles as the primary-language cell) via `appendLintNote`, forcing an error-red background. Now uses `appendLintNotePreserveBackground` — still signals via red font + note, leaves the user's A1 background intact.
2. **Missing-Applies-header warning is now visible** — it was placed at `Math.max(lastCol + 1, 4)`, landing in an off-screen empty column on wide sheets. Now placed on the conventional Applies column **D**, realizing the intent the existing comment already described.
3. **Unrecognized Applies tokens echo original casing** — warnings showed lowercased text; they now display exactly what the user typed, while still matching case-insensitively.

## #29 — helper cleanup, perf, parity tests

- **Severity-style consolidation:** extracted `LINT_SEVERITY_STYLE` (+ `LintSeverity` alias) as the single source of truth, shared by all four lint-note writers; removed the duplicated `switch` blocks. No behavior change.
- **Rename:** `clearRangeLintNoteLinesWithPrefix(es)` → `clearRangeLintNotesWithPrefix(es)` to match the sibling `clearRange*` helpers (rename-only; the empty-prefix guard was already present).
- **Perf — profiled & documented, no change:** `getSpreadsheetData()` runs **exactly once** per lint run (only in `collectStrictLintMetrics`), so a per-execution cache would be dead code. The only remaining read overlap would require routing every check through a shared snapshot — a lint-engine redesign that is explicitly out of scope per #29's non-goals. Rationale captured in a code comment.
- **Parity-test harness extraction — evaluated, declined:** the 3 parity tests already use a uniform `cases`+loop shape and differ in assertion/format; a generic harness would add callback indirection and reduce readable failure output for marginal gain. Per #29 criterion 4 ("only if justified by test-suite growth"), not warranted.

## Note: stale GAS tests aligned

The two header-detection parity tests in `testLint.ts` had silently drifted from the merged PR #28 code — they asserted col 1 while the code emitted col 5 for the fixture. These GAS tests are **not run in CI** (the `package.yml` workflow only runs `npm test` inside `package/`), so the drift went unnoticed. Both are now aligned to the corrected column D.

## Verification

- `npx tsc --noEmit -p tsconfig.json` → clean
- `bunx biome lint src/lint.ts src/test/testLint.ts` → clean
- GAS lint/parity tests (`runLintParityTests()`) require the Apps Script runtime and were verified by static reasoning; they are not executable in CI.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers post-merge cleanup for `src/lint.ts`: three targeted behavioral fixes (A1 background preservation, missing-Applies-header warning visibility, original-casing echo in invalid token warnings) plus non-behavioral helper consolidation (centralized `LINT_SEVERITY_STYLE`, function rename, perf documentation).

- **A1 fix**: `checkTotalEntityCounts` now calls `appendLintNotePreserveBackground` instead of `appendLintNote`, preventing the >10k-entity advisory from overwriting the user-managed A1 background with error-red.
- **Applies warning placement**: Column D is now hardcoded as the target for the "No Applies header found" warning (with an explicit pre-clear of D), replacing the old `Math.max(lastCol + 1, 4)` that landed off-screen on wide sheets; tests updated from `col === 1` to `col === 4` to match.
- **Token casing**: `rawTokens` retains original user casing for display while `tokens` (lowercased) drives matching, so warnings accurately reflect what the user typed.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three behavioral changes are narrowly targeted, the helper consolidation is rename-only with no logic alterations, and the test updates correctly track the new column D placement.

The three fixes each address a clearly described regression: the A1 preserve-background swap is a one-line caller change, the column D hardcoding is accompanied by an explicit pre-clear to handle the stale-note edge case, and the rawTokens/tokens split correctly threads original casing through the warning path. The LINT_SEVERITY_STYLE extraction removes duplicated palette strings across all four lint-note writers without changing any visual output. No new control paths are introduced and TypeScript compiles cleanly.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lint.ts | Three well-scoped behavioral fixes (A1 background, Applies warning column, token casing) plus clean severity-style consolidation via LINT_SEVERITY_STYLE; all non-null assertions are correct and the append/set variants remain consistent. |
| src/test/testLint.ts | Adds an appendLintNotePreserveBackground mock (font-only, no background) and aligns two parity tests from col 1 to col 4; mock escalation logic faithfully mirrors production for all tested scenarios. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[lint run] --> B[validateAppliesColumn]
    A --> C[checkTotalEntityCounts]

    B --> D{Applies header found?}
    D -- No --> E[appliesExpectedCol = 4 always column D]
    E --> F[clearRangeLintNotesWithPrefixes cell D1]
    F --> G[appendLintNote D1 warning visible on screen]

    D -- Yes --> H[validate body tokens]
    H --> I{invalid tokens?}
    I -- Yes --> J[invalidTokens uses rawTokens original casing preserved]
    J --> K[appendLintNote with user exact text in message]

    C --> L{totalCount > 10000?}
    L -- Yes --> M[appendLintNotePreserveBackground A1 background untouched font-only error signal]

    subgraph LINT_SEVERITY_STYLE
        N[error: bg=LINT_ERROR_BG font=red]
        O[warning: bg=LINT_WARNING_BG font=orange]
        P[advisory: bg=LINT_ADVISORY_BG font=null]
    end

    M --> LINT_SEVERITY_STYLE
    K --> LINT_SEVERITY_STYLE
    G --> LINT_SEVERITY_STYLE
```

<sub>Reviews (2): Last reviewed commit: ["fix(lint): address PR #31 review feedbac..."](https://github.com/digidem/comapeo-category-spreadsheet-plugin/commit/da3ab9a706520bde94f51eae700555267e2e44c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35047972)</sub>

<!-- /greptile_comment -->