### PR TITLE
fix: use shared API_BASE_URL in preflightValidation

### DIFF
--- a/src/preflightValidation.ts
+++ b/src/preflightValidation.ts
@@ -72,7 +72,7 @@ function checkApiHealth(): PreflightValidationResult {
   const log = getScopedLogger("PreflightValidation");
   try {
     log.info("[PREFLIGHT] Checking API health...");
-    const apiUrl = "http://137.184.153.36:3000/";
+    const apiUrl = `${API_BASE_URL}/`;
 
     // Try to connect to the API with a short timeout
     const options: GoogleAppsScript.URL_Fetch.URLFetchRequestOptions = {

--- a/src/preflightValidation.ts
+++ b/src/preflightValidation.ts
@@ -72,7 +72,7 @@ function checkApiHealth(): PreflightValidationResult {
   const log = getScopedLogger("PreflightValidation");
   try {
     log.info("[PREFLIGHT] Checking API health...");
-    const apiUrl = `${API_BASE_URL}/`;
+    const apiUrl = `${API_BASE_URL.replace(/\/$/, "")}/`;
 
     // Try to connect to the API with a short timeout
     const options: GoogleAppsScript.URL_Fetch.URLFetchRequestOptions = {

--- a/src/preflightValidation.ts
+++ b/src/preflightValidation.ts
@@ -72,6 +72,8 @@ function checkApiHealth(): PreflightValidationResult {
   const log = getScopedLogger("PreflightValidation");
   try {
     log.info("[PREFLIGHT] Checking API health...");
+    // Normalize: strip any trailing slash from config, then append exactly one.
+    // Ensures consistent URL regardless of whether API_BASE_URL ends with '/'.
     const apiUrl = `${API_BASE_URL.replace(/\/$/, "")}/`;
 
     // Try to connect to the API with a short timeout

--- a/src/preflightValidation.ts
+++ b/src/preflightValidation.ts
@@ -74,7 +74,9 @@ function checkApiHealth(): PreflightValidationResult {
     log.info("[PREFLIGHT] Checking API health...");
     // Normalize: strip any trailing slash from config, then append exactly one.
     // Ensures consistent URL regardless of whether API_BASE_URL ends with '/'.
-    const apiUrl = `${API_BASE_URL.replace(/\/$/, "")}/`;
+    // Guard against undefined in case config.ts hasn't loaded yet.
+    const baseUrl = typeof API_BASE_URL !== "undefined" ? API_BASE_URL : "";
+    const apiUrl = `${baseUrl.replace(/\/$/, "")}/`;
 
     // Try to connect to the API with a short timeout
     const options: GoogleAppsScript.URL_Fetch.URLFetchRequestOptions = {


### PR DESCRIPTION
## Problem

`src/preflightValidation.ts:75` hardcoded the API URL as `"http://137.184.153.36:3000/"` instead of using the centralized `API_BASE_URL` constant from `src/config.ts:19`.

If the API URL ever changes in `config.ts`, preflight checks would hit the wrong endpoint.

## Fix

Replace hardcoded URL with template literal using the shared constant:

```diff
- const apiUrl = "http://137.184.153.36:3000/";
+ const apiUrl = `${API_BASE_URL}/`;
```

No behavior change — produces identical URL at runtime.

Closes #33

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the hardcoded IP-based URL `"http://137.184.153.36:3000/"` in `checkApiHealth` with a construction from the shared `API_BASE_URL` constant, so future changes to the server address in `config.ts` automatically propagate to preflight checks.

- **URL deduplication**: `preflightValidation.ts` now reads `API_BASE_URL` from `config.ts` instead of maintaining a separate copy of the server address.
- **Trailing-slash normalization**: A `.replace(/\\/$/, "")` call before appending `"/"` prevents double-slash URLs if `API_BASE_URL` ever gains a trailing slash.
- **Undefined guard**: The `typeof API_BASE_URL !== "undefined"` check handles the edge case where script file ordering in the GAS bundle could cause the constant to be accessed before it is initialized; the empty-string fallback safely triggers the existing error path.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal URL deduplication with no behavioral difference at runtime given the current config value.

The only changed lines swap a hardcoded string for a constant read that produces the identical URL at runtime. The typeof guard and trailing-slash normalization are both correct defensive additions, and the existing try/catch structure means any edge-case failure is absorbed gracefully.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/preflightValidation.ts | Replaces hardcoded IP URL with API_BASE_URL from config, adding a typeof undefined guard and trailing-slash normalization; logic is correct and the outer try/catch ensures the process continues safely if the guard ever activates. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GAS as Google Apps Script
    participant Config as config.ts (API_BASE_URL)
    participant Preflight as preflightValidation.ts
    participant API as CoMapeo API Server

    GAS->>Preflight: runPreflightChecks()
    Preflight->>Preflight: checkApiHealth()
    Preflight->>Config: read API_BASE_URL
    Config-->>Preflight: "http://137.184.153.36:3000"
    Preflight->>Preflight: strip trailing slash + append "/"
    Note over Preflight: apiUrl = "http://137.184.153.36:3000/"
    Preflight->>API: UrlFetchApp.fetch(apiUrl)
    API-->>Preflight: HTTP 200 / 404 / error
    Preflight-->>GAS: "PreflightValidationResult { passed, message }"
```

<sub>Reviews (6): Last reviewed commit: ["fix: add typeof guard for API\_BASE\_URL i..."](https://github.com/digidem/comapeo-category-spreadsheet-plugin/commit/fd153aa60e1dd90459a029fb65ea0839a95f008c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35353937)</sub>

<!-- /greptile_comment -->