### PR TITLE
fix: add TAR extraction depth limit and PNG magic byte validation

### DIFF
--- a/src/importCategory/extractPngIcons.ts
+++ b/src/importCategory/extractPngIcons.ts
@@ -19,6 +19,34 @@ function safePngDebugLog(message: string, forceFlush = false): void {
 }
 
 /**
+ * PNG file signature bytes (first 8 bytes of any valid PNG file)
+ */
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+/**
+ * Validates that a file has a valid PNG signature
+ * @param file - Drive file to validate
+ * @returns true if file starts with valid PNG signature
+ */
+function validatePngSignature(file: GoogleAppsScript.Drive.File): boolean {
+  try {
+    const bytes = file.getBlob().getBytes();
+    if (bytes.length < PNG_SIGNATURE.length) {
+      return false;
+    }
+    for (let i = 0; i < PNG_SIGNATURE.length; i++) {
+      if (bytes[i] !== PNG_SIGNATURE[i]) {
+        return false;
+      }
+    }
+    return true;
+  } catch (error) {
+    safePngDebugLog(`Failed to validate PNG signature for ${file.getName()}: ${error}`);
+    return false;
+  }
+}
+
+/**
  * Updates an existing Drive file in place so its file ID and URL stay stable.
  * Uses the Drive upload endpoint because DriveApp does not support binary
  * content replacement for PNG files.
@@ -206,8 +234,14 @@ function extractPngIcons(
         return; // Skip this icon
       }
 
-      safePngDebugLog(`  ✓ Found PNG for "${iconName}": ${foundPattern}`);
+      // Validate PNG signature before processing
+      if (!validatePngSignature(foundFile)) {
+        console.warn(`Invalid PNG signature for icon: ${iconName} (${foundPattern})`);
+        failedIcons.push({ name: iconName, error: `File does not have a valid PNG signature: ${foundPattern}` });
+        return;
+      }
 
+      safePngDebugLog(`  ✓ Found PNG for "${iconName}": ${foundPattern}`);
       // Copy to permanent folder
       try {
         const fileName = `${iconName}.png`;

--- a/src/importCategory/extractPngIcons.ts
+++ b/src/importCategory/extractPngIcons.ts
@@ -24,27 +24,29 @@ function safePngDebugLog(message: string, forceFlush = false): void {
 const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
 
 /**
- * Validates that a file has a valid PNG signature
+ * Validates that a file has a valid PNG signature and returns its blob.
+ * Returns null if the file is not a valid PNG.
  * @param file - Drive file to validate
- * @returns true if file starts with valid PNG signature
+ * @returns The file's blob if valid PNG, null otherwise
  */
-function validatePngSignature(file: GoogleAppsScript.Drive.File): boolean {
+function validatePngAndGetBlob(file: GoogleAppsScript.Drive.File): GoogleAppsScript.Base.Blob | null {
   try {
-    const bytes = file.getBlob().getBytes();
+    const blob = file.getBlob();
+    const bytes = blob.getBytes();
     if (bytes.length < PNG_SIGNATURE.length) {
-      return false;
+      return null;
     }
     for (let i = 0; i < PNG_SIGNATURE.length; i++) {
       // GAS Blob.getBytes() returns Java signed bytes (-128 to 127).
       // Mask with 0xff to convert to unsigned for comparison.
       if ((bytes[i] & 0xff) !== PNG_SIGNATURE[i]) {
-        return false;
+        return null;
       }
     }
-    return true;
+    return blob;
   } catch (error) {
     safePngDebugLog(`Failed to validate PNG signature for ${file.getName()}: ${error}`);
-    return false;
+    return null;
   }
 }
 
@@ -236,15 +238,16 @@ function extractPngIcons(
         return; // Skip this icon
       }
 
-      // Validate PNG signature before processing
-      if (!validatePngSignature(foundFile)) {
+      // Validate PNG signature and get blob in single fetch
+      const validatedBlob = validatePngAndGetBlob(foundFile);
+      if (!validatedBlob) {
         console.warn(`Invalid PNG signature for icon: ${iconName} (${foundPattern})`);
         failedIcons.push({ name: iconName, error: `File does not have a valid PNG signature: ${foundPattern}` });
         return;
       }
 
-      safePngDebugLog(`  ✓ Found PNG for "${iconName}": ${foundPattern}`);
-      // Copy to permanent folder
+      safePngDebugLog(`  ✓ Found valid PNG for "${iconName}": ${foundPattern}`);
+      // Copy to permanent folder using pre-validated blob
       try {
         const fileName = `${iconName}.png`;
         const existingFiles = permanentIconsFolder.getFilesByName(fileName);
@@ -253,12 +256,12 @@ function extractPngIcons(
         if (existingFiles.hasNext()) {
           const existingFile = existingFiles.next();
           const oldSize = existingFile.getSize();
-          const blob = foundFile.getBlob().setName(fileName);
+          const blob = validatedBlob.setName(fileName);
           permanentFile = updateDriveFileBlobInPlace(existingFile, blob);
           const newSize = permanentFile.getSize();
           safePngDebugLog(`  ↻ Updated existing "${fileName}" in place: ${oldSize} → ${newSize} bytes`);
         } else {
-          const blob = foundFile.getBlob().setName(fileName);
+          const blob = validatedBlob.setName(fileName);
           permanentFile = permanentIconsFolder.createFile(blob);
           const fileSize = permanentFile.getSize();
           safePngDebugLog(`  ✓ Created "${fileName}": ${fileSize} bytes`);

--- a/src/importCategory/extractPngIcons.ts
+++ b/src/importCategory/extractPngIcons.ts
@@ -35,7 +35,9 @@ function validatePngSignature(file: GoogleAppsScript.Drive.File): boolean {
       return false;
     }
     for (let i = 0; i < PNG_SIGNATURE.length; i++) {
-      if (bytes[i] !== PNG_SIGNATURE[i]) {
+      // GAS Blob.getBytes() returns Java signed bytes (-128 to 127).
+      // Mask with 0xff to convert to unsigned for comparison.
+      if ((bytes[i] & 0xff) !== PNG_SIGNATURE[i]) {
         return false;
       }
     }

--- a/src/importCategory/fileExtractor.ts
+++ b/src/importCategory/fileExtractor.ts
@@ -715,7 +715,9 @@ function extractTarArchiveInternal(
 
         const shouldExtract = isCoreFile || isIconFile;
 
-        // Check depth before extracting payload to avoid memory waste
+        // Check depth before extracting payload to avoid memory waste.
+        // Only icon files are checked because core config files (metadata.json,
+        // presets.json, etc.) are always flat names in .comapeocat archives.
         if (!isDirectory && isIconFile && fileName.includes("/")) {
           const dirPath = fileName.substring(0, fileName.lastIndexOf("/"));
           const parts = dirPath.split("/");

--- a/src/importCategory/fileExtractor.ts
+++ b/src/importCategory/fileExtractor.ts
@@ -200,6 +200,12 @@ function createIconSpriteFromArray(icons: Array<{ name?: string; svg?: string }>
 const MAX_FILE_SIZE = 100 * 1024 * 1024;
 
 /**
+ * Maximum directory depth for TAR extraction paths.
+ * Prevents zip-slip / resource-exhaustion via deeply nested entries.
+ */
+const MAX_TAR_PATH_DEPTH = 10;
+
+/**
  * Validates a file path to prevent path traversal attacks
  *
  * @param path - The file path to validate
@@ -738,6 +744,16 @@ function extractTarArchiveInternal(
             // Create nested folders if they don't exist
             let currentFolder = tempFolder;
             const parts = dirPath.split("/");
+
+            if (parts.length > MAX_TAR_PATH_DEPTH) {
+              console.warn(`Skipping deeply nested path (${parts.length} levels, max ${MAX_TAR_PATH_DEPTH}): ${dirPath}`);
+              // Still advance position so parsing continues
+              const dataBlocks = Math.ceil(fileSize / BLOCK_SIZE);
+              position += HEADER_SIZE + dataBlocks * BLOCK_SIZE;
+              processedFiles.add(fileName);
+              fileCount++;
+              continue;
+            }
 
             for (const part of parts) {
               if (part) {

--- a/src/importCategory/fileExtractor.ts
+++ b/src/importCategory/fileExtractor.ts
@@ -715,6 +715,20 @@ function extractTarArchiveInternal(
 
         const shouldExtract = isCoreFile || isIconFile;
 
+        // Check depth before extracting payload to avoid memory waste
+        if (!isDirectory && isIconFile && fileName.includes("/")) {
+          const dirPath = fileName.substring(0, fileName.lastIndexOf("/"));
+          const parts = dirPath.split("/");
+          if (parts.length > MAX_TAR_PATH_DEPTH) {
+            console.warn(`Skipping deeply nested path (${parts.length} levels, max ${MAX_TAR_PATH_DEPTH}): ${dirPath}`);
+            const dataBlocks = Math.ceil(fileSize / BLOCK_SIZE);
+            position += HEADER_SIZE + dataBlocks * BLOCK_SIZE;
+            processedFiles.add(fileName);
+            fileCount++;
+            continue;
+          }
+        }
+
         if (!isDirectory && shouldExtract) {
           // Extract file data
           const fileData = bytes.slice(
@@ -744,16 +758,6 @@ function extractTarArchiveInternal(
             // Create nested folders if they don't exist
             let currentFolder = tempFolder;
             const parts = dirPath.split("/");
-
-            if (parts.length > MAX_TAR_PATH_DEPTH) {
-              console.warn(`Skipping deeply nested path (${parts.length} levels, max ${MAX_TAR_PATH_DEPTH}): ${dirPath}`);
-              // Still advance position so parsing continues
-              const dataBlocks = Math.ceil(fileSize / BLOCK_SIZE);
-              position += HEADER_SIZE + dataBlocks * BLOCK_SIZE;
-              processedFiles.add(fileName);
-              fileCount++;
-              continue;
-            }
 
             for (const part of parts) {
               if (part) {


### PR DESCRIPTION
## Problem

Two security gaps in the import pipeline:

### 1. No TAR extraction depth limit
`src/importCategory/fileExtractor.ts` had no depth limit on TAR path extraction. `driveService.ts` and `cleanup.ts` both have `MAX_FOLDER_DEPTH` guards, but TAR extraction had no equivalent. A malicious `.comapeocat` archive with deeply nested paths could cause resource exhaustion.

### 2. No PNG magic byte validation
`src/importCategory/extractPngIcons.ts` accepted any file as PNG without checking the PNG signature bytes. Corrupt or non-PNG files would fail silently or cause confusing errors downstream.

## Changes

### fileExtractor.ts
- Added `MAX_TAR_PATH_DEPTH = 10` constant
- Path depth check before extraction: splits path on `/` and rejects entries exceeding the limit
- Skipped entries still advance the TAR position so parsing continues correctly

### extractPngIcons.ts
- Added `PNG_MAGIC_BYTES` constant (`89 50 4E 47 0D 0A 1A 0A`)
- `validatePngSignature()` checks first 8 bytes against expected PNG header
- Invalid files rejected early with clear error message

No behavior changes for valid archives. Only rejects malicious/corrupt inputs.

Closes #37

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes two import-pipeline security gaps: TAR entries with deeply nested paths are now rejected before their data is read, and PNG files are validated against the 8-byte PNG signature before being written to Drive.

- **`fileExtractor.ts`**: Adds `MAX_TAR_PATH_DEPTH = 10`; icon-file entries whose directory component exceeds 10 levels are skipped with correct position arithmetic so TAR parsing continues normally for subsequent entries. Core config files (`metadata.json`, etc.) are unaffected — they are matched by exact flat filename.
- **`extractPngIcons.ts`**: Adds `validatePngAndGetBlob()` which reads the file blob once, masks each byte with `0xff` to handle GAS's Java-signed-byte representation, and compares against `PNG_SIGNATURE`. The validated blob is reused downstream, eliminating a redundant Drive API call.

<h3>Confidence Score: 5/5</h3>

Both changes are narrow, additive guards with no behavior change for valid inputs; safe to merge.

The TAR depth check correctly mirrors the position-advancement arithmetic used by the main loop, so skipping a deeply-nested entry leaves the parser in a consistent state. The PNG validation correctly handles GAS's signed-byte representation with `& 0xff`, which was the key correctness concern for this environment. Neither change alters the happy path for well-formed `.comapeocat` archives.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/importCategory/extractPngIcons.ts | Adds PNG magic-byte validation via `validatePngAndGetBlob()` with correct signed-byte masking (`& 0xff`), reuses the fetched blob to avoid a double Drive API call, and integrates validation into the icon extraction loop with proper error reporting. |
| src/importCategory/fileExtractor.ts | Adds `MAX_TAR_PATH_DEPTH = 10` constant and a pre-extraction depth guard for icon files; position advancement in the skip path matches the main loop's arithmetic, so TAR parsing stays consistent after a skipped entry. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[TAR Entry Read] --> B{isIconFile?}
    B -- No --> C{isCoreFile exact match?}
    C -- No --> Z[Advance position / skip entry]
    C -- Yes --> D[Extract core file to tempFolder]
    D --> Z
    B -- Yes --> E{dirPath parts > MAX_TAR_PATH_DEPTH?}
    E -- Yes --> F[warn + advance position, continue]
    E -- No --> G[Extract icon data, create nested folders]
    G --> Z

    H[Drive File Found] --> I[validatePngAndGetBlob]
    I --> J[getBlob + getBytes]
    J --> K{bytes.length < 8?}
    K -- Yes --> L[return null / failedIcons]
    K -- No --> M{bytes i and 0xff === PNG_SIGNATURE i?}
    M -- No --> L
    M -- Yes --> N[return blob]
    N --> O[setName + createFile or updateInPlace]
```

<sub>Reviews (7): Last reviewed commit: ["docs: explain why TAR depth check only a..."](https://github.com/digidem/comapeo-category-spreadsheet-plugin/commit/4a1117f7c03c0fbe794b89a7cc6270d2597e9922) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35356153)</sub>

<!-- /greptile_comment -->