### PR TITLE
fix: clarify English sheet names in Spanish help dialog

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2,7 +2,7 @@
 // Apps Script will compile all .ts files together, making them globally available
 
 let activeUserLocale = Session.getActiveUserLocale().split("_")[0];
-const supportedLocales = ["en", "es"];
+const supportedLocales = ["en", "es", "pt"];
 const defaultLocale = "en";
 let activeLocale = supportedLocales.includes(activeUserLocale)
   ? activeUserLocale

--- a/src/dialog.ts
+++ b/src/dialog.ts
@@ -7,6 +7,14 @@
 const COMAPEO_LOGO_SVG = "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20100%20100%22%3E%3Cdefs%3E%3ClinearGradient%20id%3D%22grad1%22%20x1%3D%220%25%22%20y1%3D%220%25%22%20x2%3D%22100%25%22%20y2%3D%22100%25%22%3E%3Cstop%20offset%3D%220%25%22%20style%3D%22stop-color%3A%236d44d9%3Bstop-opacity%3A1%22%20%2F%3E%3Cstop%20offset%3D%22100%25%22%20style%3D%22stop-color%3A%23330B9E%3Bstop-opacity%3A1%22%20%2F%3E%3C%2FlinearGradient%3E%3C%2Fdefs%3E%3Ccircle%20cx%3D%2250%22%20cy%3D%2250%22%20r%3D%2248%22%20fill%3D%22url(%23grad1)%22%20%2F%3E%3Cpath%20fill%3D%22white%22%20d%3D%22M50%2025c-8.28%200-15%206.72-15%2015%200%2011.25%2015%2030%2015%2030s15-18.75%2015-30c0-8.28-6.72-15-15-15zm0%2020.5c-3.04%200-5.5-2.46-5.5-5.5s2.46-5.5%205.5-5.5%205.5%202.46%205.5%205.5-2.46%205.5-5.5%205.5z%22%2F%3E%3C%2Fsvg%3E";
 
 /**
+ * Resolve locale for dialog text maps. Falls back to "en" if the
+ * current locale has no translations, preventing undefined crashes.
+ */
+function resolveLocale<T>(textMap: Record<string, T>): string {
+  return textMap[locale] ? locale : "en";
+}
+
+/**
  * CRITICAL: Safe dialog wrapper that validates HTML before showing
  * This prevents "Malformed HTML content" errors
  */
@@ -322,9 +330,10 @@ function generateDialog(
 }
 
 function showIconsGeneratedDialog(folderUrl: string) {
-  const title = iconDialogTexts[locale].title;
-  const message = validateAndSanitizeMessage(iconDialogTexts[locale].message);
-  const buttonText = iconDialogTexts[locale].buttonText;
+  const dl = resolveLocale(iconDialogTexts);
+  const title = iconDialogTexts[dl].title;
+  const message = validateAndSanitizeMessage(iconDialogTexts[dl].message);
+  const buttonText = iconDialogTexts[dl].buttonText;
   const html = generateDialog(title, message, buttonText, folderUrl);
   showModalDialogSafe(html, title, 800, 600, "Icons Generated");
 }
@@ -363,7 +372,7 @@ function closeProcessingModalDialog(): void {
  * This function will close and reopen the dialog with updated content.
  */
 function updateProcessingDialogProgress(mainMessage: string, detailMessage?: string) {
-  const title = processingDialogTitle[locale];
+  const title = processingDialogTitle[resolveLocale(processingDialogTitle)];
   const messageLines = detailMessage
     ? [mainMessage, detailMessage]
     : [mainMessage];
@@ -378,15 +387,16 @@ function updateProcessingDialogProgress(mainMessage: string, detailMessage?: str
 }
 
 function showConfigurationGeneratedDialog(folderUrl: string) {
-  const title = generatedConfigDialogTexts[locale].title;
-  const message = validateAndSanitizeMessage(generatedConfigDialogTexts[locale].message);
-  const buttonText = generatedConfigDialogTexts[locale].buttonText;
+  const dl = resolveLocale(generatedConfigDialogTexts);
+  const title = generatedConfigDialogTexts[dl].title;
+  const message = validateAndSanitizeMessage(generatedConfigDialogTexts[dl].message);
+  const buttonText = generatedConfigDialogTexts[dl].buttonText;
   const html = generateDialog(title, message, buttonText, folderUrl);
   showModalDialogSafe(html, title, 800, 980, "Configuration Generated");
 }
 
 function showHelpDialog() {
-  const helpLocale = helpDialogTexts[locale] ? locale : "en";
+  const helpLocale = resolveLocale(helpDialogTexts);
   const title = helpDialogTexts[helpLocale].title;
   const msgHeader = validateAndSanitizeMessage(helpDialogTexts[helpLocale].message);
 
@@ -427,7 +437,8 @@ function showHelpDialog() {
 function showSelectTranslationLanguagesDialog() {
   const primaryLanguage = getPrimaryLanguage();
   const availableTargetLanguages = getAvailableTargetLanguages();
-  const dialogText = selectTranslationLanguagesDialogText[locale];
+  const dl = resolveLocale(selectTranslationLanguagesDialogText);
+  const dialogText = selectTranslationLanguagesDialogText[dl];
 
   const title = dialogText.title;
   const messageTemplate = dialogText.message;
@@ -909,7 +920,8 @@ function getErrorTypeLabel(errorType: string): string {
  * @param errorSummary - Summary of icon errors from processing
  */
 function showIconErrorDialog(errorSummary: IconErrorSummary): void {
-  const title = iconErrorDialogTexts[locale].title;
+  const dl = resolveLocale(iconErrorDialogTexts);
+  const title = iconErrorDialogTexts[dl].title;
 
   // Build summary message
   const summaryLines: string[] = [];
@@ -1004,12 +1016,12 @@ function showIconErrorDialog(errorSummary: IconErrorSummary): void {
   const html = generateDialog(
     title,
     message,
-    iconErrorDialogTexts[locale].downloadButtonText,
+    iconErrorDialogTexts[dl].downloadButtonText,
     undefined,
     "downloadIconErrorReport",
     errorSummary.errorCount > 0
-      ? iconErrorDialogTexts[locale].continueButtonText
-      : iconErrorDialogTexts[locale].okButtonText,
+      ? iconErrorDialogTexts[dl].continueButtonText
+      : iconErrorDialogTexts[dl].okButtonText,
     "google.script.host.close",
   );
 

--- a/src/dialog.ts
+++ b/src/dialog.ts
@@ -386,11 +386,12 @@ function showConfigurationGeneratedDialog(folderUrl: string) {
 }
 
 function showHelpDialog() {
-  const title = helpDialogTexts[locale].title;
-  const msgHeader = validateAndSanitizeMessage(helpDialogTexts[locale].message);
+  const helpLocale = helpDialogTexts[locale] ? locale : "en";
+  const title = helpDialogTexts[helpLocale].title;
+  const msgHeader = validateAndSanitizeMessage(helpDialogTexts[helpLocale].message);
 
   // Instructions already contain HTML tags (like <br /> and <a>), validate them
-  const instructions = helpDialogTexts[locale].instructions
+  const instructions = helpDialogTexts[helpLocale].instructions
     .map((instruction) => {
       // Validate each instruction's HTML if it contains tags
       if (/<\w+/.test(instruction)) {
@@ -407,7 +408,7 @@ function showHelpDialog() {
     })
     .join("\n");
 
-  const footer = `<p>${escapeHtml(helpDialogTexts[locale].footer)}</p>`;
+  const footer = `<p>${escapeHtml(helpDialogTexts[helpLocale].footer)}</p>`;
 
   const message = `
   ${msgHeader}
@@ -416,7 +417,7 @@ function showHelpDialog() {
   </ol>
   ${footer}
 `;
-  const buttonText = helpDialogTexts[locale].buttonText;
+  const buttonText = helpDialogTexts[helpLocale].buttonText;
   const buttonUrl =
     "https://github.com/digidem/comapeo-config-spreadsheet-plugin";
   const html = generateDialog(title, message, buttonText, buttonUrl);

--- a/src/text/dialog.ts
+++ b/src/text/dialog.ts
@@ -112,6 +112,26 @@ let helpDialogTexts: Record<string, DialogText & DialogInstructions> = {
     footer: "Para más información, visite nuestro repositorio de Github",
     buttonText: "Visite repositorio de Github",
   },
+  pt: {
+    title: "Ferramentas CoMapeo - Ajuda",
+    message: [
+      "Bem-vindo às ferramentas do CoMapeo! Este complemento ajudará você a organizar e criar categorias do CoMapeo. É usado assim:",
+      "A lógica de trabalho para criar e organizar categorias do CoMapeo é a seguinte:",
+    ],
+    instructions: [
+      "Edite as planilhas chamadas 'Categories' (categorias) e 'Details' (detalhes) para definir suas próprias categorias e seus detalhes associados. Observe que a cor de fundo selecionada para categorias e ícones será refletida no aplicativo CoMapeo.",
+      "Use a opção 'Gerenciar Idiomas e Traduzir' para adicionar colunas de idiomas manuais e traduzir automaticamente as células vazias.",
+      "Revise e refine as traduções geradas automaticamente conforme necessário.",
+      "Use a opção 'Gerar Ícones' para criar ícones para suas categorias. A cor de fundo dos ícones corresponderá à cor definida na planilha.",
+      "Verifique os ícones gerados na pasta de ícones e modifique-os usando o <br /><a href='https://icons.earthdefenderstoolkit.com' target='_blank'>Gerador de Ícones</a> se necessário.",
+      "Copie o link compartilhado de cada ícone e cole na célula correspondente da planilha.",
+      "Use a opção 'Validar Planilhas' para garantir a formatação e capitalização adequadas dos seus dados.",
+      "Repita as etapas anteriores conforme necessário, atualizando traduções e ícones até ficar satisfeito com os resultados.",
+      "Quando estiver pronto, use a opção 'Gerar Categoria CoMapeo' para criar seu arquivo final. Este processo pode levar alguns minutos e gerará um arquivo '.comapeocat' salvo no Google Drive, pronto para uso com o aplicativo CoMapeo.",
+    ],
+    footer: "Para mais informações, visite nosso repositório no Github",
+    buttonText: "Visite repositório no Github",
+  },
   en: {
     title: "CoMapeo Tools Help",
     message: [

--- a/src/text/dialog.ts
+++ b/src/text/dialog.ts
@@ -49,6 +49,31 @@ let selectTranslationLanguagesDialogText: Record<string, SelectTranslationDialog
       invalidCustomIso: "Custom ISO codes should contain letters and optional hyphens (e.g. qu, quz, pt-br).",
     },
   },
+  pt: {
+    title: "Selecionar idiomas de destino",
+    buttonText: "Traduzir",
+    skipButtonText: "Cancelar",
+    message: [
+      "Selecione os idiomas para os quais deseja traduzir automaticamente de {{sourceLanguage}}:",
+      "Apenas os idiomas selecionados abaixo receberão traduções automáticas.",
+      "Adicione idiomas manuais na seção abaixo.",
+    ],
+    manualSectionTitle: "Idiomas personalizados (colunas manuais)",
+    manualSectionDescription: [
+      "Adicione colunas de idiomas adicionais em todas as planilhas de tradução.",
+      "Estes idiomas não são traduzidos automaticamente — você pode preenchê-los depois.",
+    ],
+    manualDropdownPlaceholder: "Selecione um idioma comum",
+    manualAddButton: "Adicionar outro idioma",
+    manualNamePlaceholder: "Nome do idioma (ex. Quíchua)",
+    manualIsoPlaceholder: "Código ISO (ex. qu)",
+    validationMessages: {
+      noAutoSelection: "Selecione pelo menos um idioma para traduzir ou clique em 'Cancelar'.",
+      missingCustomFields: "Preencha o nome e o código ISO para cada idioma personalizado.",
+      duplicateCustomIso: "Códigos ISO personalizados duplicados. Verifique e tente novamente.",
+      invalidCustomIso: "Os códigos ISO devem conter letras e hifens opcionais (ex. qu, quz, pt-br).",
+    },
+  },
 };
 
 let iconDialogTexts: Record<string, DialogText> = {
@@ -70,6 +95,15 @@ let iconDialogTexts: Record<string, DialogText> = {
     ],
     buttonText: "View Generated Icons",
   },
+  pt: {
+    title: "Ícones CoMapeo Gerados",
+    message: [
+      "Seus ícones CoMapeo foram gerados com sucesso e salvos em uma pasta no Google Drive.",
+      "Para visualizar e gerenciar seus ícones, clique no botão abaixo. Você pode baixar, modificar ou substituir os ícones conforme necessário.",
+      "Lembre-se de atualizar as URLs dos ícones na planilha se fizer alguma alteração.",
+    ],
+    buttonText: "Ver Ícones Gerados",
+  },
 };
 
 let generatedConfigDialogTexts: Record<string, DialogText> = {
@@ -88,6 +122,14 @@ let generatedConfigDialogTexts: Record<string, DialogText> = {
       "To download or share it, click the button below. The .comapeocat file is ready to import into the CoMapeo app.",
     ],
     buttonText: "Download CoMapeo Category",
+  },
+  pt: {
+    title: "Categoria CoMapeo Gerada",
+    message: [
+      "Seu arquivo de Categoria CoMapeo foi gerado com sucesso e salvo no Google Drive.",
+      "Para baixar ou compartilhar, clique no botão abaixo. O arquivo .comapeocat está pronto para importação no aplicativo CoMapeo.",
+    ],
+    buttonText: "Baixar Categoria CoMapeo",
   },
 };
 
@@ -157,6 +199,7 @@ let helpDialogTexts: Record<string, DialogText & DialogInstructions> = {
 let processingDialogTitle: Record<string, string> = {
   en: "Generating CoMapeo Category",
   es: "Generando Categoría CoMapeo",
+  pt: "Gerando Categoria CoMapeo",
 };
 
 let iconErrorDialogTexts: Record<string, IconErrorDialogText> = {
@@ -172,6 +215,12 @@ let iconErrorDialogTexts: Record<string, IconErrorDialogText> = {
     continueButtonText: "Continuar de Todos Modos",
     okButtonText: "OK",
   },
+  pt: {
+    title: "Relatório de Processamento de Ícones",
+    downloadButtonText: "Baixar Relatório de Erros",
+    continueButtonText: "Continuar Mesmo Assim",
+    okButtonText: "OK",
+  },
 };
 
 let processingDialogTexts: Record<string, DialogText>[] = [
@@ -185,6 +234,10 @@ let processingDialogTexts: Record<string, DialogText>[] = [
       title: processingDialogTitle["es"],
       message: ["Inicializando... (1/8)", "Validando y leyendo datos de la planilla"],
     },
+    pt: {
+      title: processingDialogTitle["pt"],
+      message: ["Inicializando... (1/8)", "Validando e lendo dados da planilha"],
+    },
   },
   // Step 2: Translating (conditional - only shown if languages selected)
   {
@@ -195,6 +248,10 @@ let processingDialogTexts: Record<string, DialogText>[] = [
     es: {
       title: processingDialogTitle["es"],
       message: ["Traduciendo... (2/8)", "Generando traducciones automáticas"],
+    },
+    pt: {
+      title: processingDialogTitle["pt"],
+      message: ["Traduzindo... (2/8)", "Gerando traduções automáticas"],
     },
   },
   // Step 3: Processing data
@@ -207,6 +264,10 @@ let processingDialogTexts: Record<string, DialogText>[] = [
       title: processingDialogTitle["es"],
       message: ["Preparando solicitud... (3/8)", "Recopilando datos de la planilla"],
     },
+    pt: {
+      title: processingDialogTitle["pt"],
+      message: ["Preparando solicitação... (3/8)", "Coletando dados da planilha"],
+    },
   },
   // Step 4: Building payload
   {
@@ -217,6 +278,10 @@ let processingDialogTexts: Record<string, DialogText>[] = [
     es: {
       title: processingDialogTitle["es"],
       message: ["Creando payload... (4/8)", "Generando JSON para la API"],
+    },
+    pt: {
+      title: processingDialogTitle["pt"],
+      message: ["Criando payload... (4/8)", "Gerando JSON para a API"],
     },
   },
   // Step 5: Sending request
@@ -229,6 +294,10 @@ let processingDialogTexts: Record<string, DialogText>[] = [
       title: processingDialogTitle["es"],
       message: ["Enviando solicitud... (5/8)", "Enviando generación a la API"],
     },
+    pt: {
+      title: processingDialogTitle["pt"],
+      message: ["Enviando solicitação... (5/8)", "Enviando geração para a API"],
+    },
   },
   // Step 6: Waiting for response
   {
@@ -239,6 +308,10 @@ let processingDialogTexts: Record<string, DialogText>[] = [
     es: {
       title: processingDialogTitle["es"],
       message: ["Esperando respuesta... (6/8)", "Esto puede tardar algunos minutos"],
+    },
+    pt: {
+      title: processingDialogTitle["pt"],
+      message: ["Aguardando resposta... (6/8)", "Isso pode levar alguns minutos"],
     },
   },
   // Step 7: Saving to Drive
@@ -251,6 +324,10 @@ let processingDialogTexts: Record<string, DialogText>[] = [
       title: processingDialogTitle["es"],
       message: ["Guardando en Drive... (7/8)", "Guardando el archivo .comapeocat"],
     },
+    pt: {
+      title: processingDialogTitle["pt"],
+      message: ["Salvando no Drive... (7/8)", "Salvando o arquivo .comapeocat"],
+    },
   },
   // Step 8: Complete
   {
@@ -261,6 +338,10 @@ let processingDialogTexts: Record<string, DialogText>[] = [
     es: {
       title: processingDialogTitle["es"],
       message: ["¡Completo! (8/8)", "Categoría CoMapeo lista para descargar"],
+    },
+    pt: {
+      title: processingDialogTitle["pt"],
+      message: ["Concluído! (8/8)", "Categoria CoMapeo pronta para baixar"],
     },
   },
 ];

--- a/src/text/dialog.ts
+++ b/src/text/dialog.ts
@@ -99,8 +99,7 @@ let helpDialogTexts: Record<string, DialogText & DialogInstructions> = {
       "La lógica de trabajo para crear y organizar categorías de CoMapeo es la siguiente:",
     ],
     instructions: [
-      // TODO: sheets shouls also be translated
-      "Edita las hojas llamadas 'Categories' y 'Details' para definir sus categorías propias y sus detalles asociados. Note que el color de fondo que seleccione para las categorías e íconos se verá reflejado en la app de CoMapeo",
+      "Edita las hojas llamadas 'Categories' (categorías) y 'Details' (detalles) para definir sus categorías propias y sus detalles asociados. Note que el color de fondo que seleccione para las categorías e íconos se verá reflejado en la app de CoMapeo",
       "Usa la opción 'Gestionar idiomas y traducir' para agregar idiomas personalizados y generar traducciones automáticamente para las celdas vacías",
       "Revise y refine las traducciones auto-generadas cuánto sea necesario",
       "Use la opción 'Generar Íconos para Categorías' para crear íconos para sus categorías. El color de fondo de los íconos coincidirá con el color que eliga en la planilla.",

--- a/src/text/menu.ts
+++ b/src/text/menu.ts
@@ -26,6 +26,19 @@ let menuTexts: Record<string, MainMenuText> = {
     cleanAllSheets: "Reset Spreadsheet",
     openHelpPage: "Help",
   },
+  pt: {
+    menu: "Ferramentas CoMapeo",
+    translateCoMapeoCategory: "Gerenciar idiomas e traduzir",
+    generateIcons: "Gerar Ícones para Categorias",
+    generateCoMapeoCategory: "Gerar Categoria CoMapeo",
+    generateCoMapeoCategoryDebug: "Exportar arquivos brutos",
+    debugMenuTitle: "Depuração",
+    importCategoryFile: "Importar arquivo de categoria",
+    importCoMapeoCategory: "Importar arquivo de categoria",
+    lintAllSheets: "Validar Planilhas",
+    cleanAllSheets: "Resetar Planilhas",
+    openHelpPage: "Ajuda",
+  },
 };
 
 let translateMenuTexts: Record<string, MenuText> = {
@@ -47,6 +60,15 @@ let translateMenuTexts: Record<string, MenuText> = {
     error: "Error",
     errorText: "An error occurred during translation: ",
   },
+  pt: {
+    action: "Gerenciar idiomas e traduzir",
+    actionText:
+      "Isso traduzirá todas as células vazias nas outras colunas de tradução de idiomas. Continuar?",
+    completed: "Tradução Concluída",
+    completedText: "Todas as planilhas foram traduzidas com sucesso.",
+    error: "Erro",
+    errorText: "Ocorreu um erro durante a tradução: ",
+  },
 };
 
 let iconMenuTexts: Record<string, MenuText> = {
@@ -64,6 +86,13 @@ let iconMenuTexts: Record<string, MenuText> = {
     error: "Error",
     errorText: "An error occurred while generating the icons: ",
   },
+  pt: {
+    action: "Gerar Ícones",
+    actionText:
+      "Esta ação gerará ícones usando as informações da planilha atual. Isso pode levar alguns minutos para processar. Continuar?",
+    error: "Erro",
+    errorText: "Ocorreu um erro ao gerar os ícones: ",
+  },
 };
 
 let categoryMenuTexts: Record<string, MenuText> = {
@@ -80,6 +109,13 @@ let categoryMenuTexts: Record<string, MenuText> = {
       "This will generate a CoMapeo category based on the current spreadsheet data. It may take a few minutes to process. Continue?",
     error: "Error",
     errorText: "An error occurred while generating the category: ",
+  },
+  pt: {
+    action: "Gerar Categorias CoMapeo",
+    actionText:
+      "Isso gerará as categorias do CoMapeo com base nos dados da planilha atual. Pode levar alguns minutos para processar. Continuar?",
+    error: "Erro",
+    errorText: "Ocorreu um erro ao gerar a categoria: ",
   },
 };
 
@@ -100,6 +136,14 @@ let categoryDebugMenuTexts: Record<string, MenuText> = {
     errorText:
       "An error occurred while generating the category in debug mode: ",
   },
+  pt: {
+    action: "Depuração: Exportar Arquivos Brutos",
+    actionText:
+      "O modo de depuração executa o gerador padrão (a exportação rawBuild está obsoleta). Continuar?",
+    error: "Erro",
+    errorText:
+      "Ocorreu um erro ao gerar a categoria no modo de depuração: ",
+  },
 };
 
 let lintMenuTexts: Record<string, MenuText> = {
@@ -119,6 +163,15 @@ let lintMenuTexts: Record<string, MenuText> = {
     completedText: "All sheets have been linted successfully.",
     error: "Error",
     errorText: "An error occurred during linting: ",
+  },
+  pt: {
+    action: "Validar Categorias CoMapeo",
+    actionText:
+      "Isso validará todas as planilhas na planilha. Continuar?",
+    completed: "Validação Concluída",
+    completedText: "Todas as planilhas foram validadas com sucesso.",
+    error: "Erro",
+    errorText: "Ocorreu um erro durante a validação: ",
   },
 };
 
@@ -141,6 +194,15 @@ let cleanAllMenuTexts: Record<string, MenuText> = {
     error: "Error",
     errorText: "An error occurred during reset: ",
   },
+  pt: {
+    action: "Resetar Planilhas",
+    actionText:
+      "Atenção! Isso removerá todas as traduções, metadados e ícones da planilha. Esta ação não pode ser desfeita. Continuar?",
+    completed: "Redefinição Concluída",
+    completedText: "Todas as planilhas foram redefinidas com sucesso.",
+    error: "Erro",
+    errorText: "Ocorreu um erro durante a redefinição: ",
+  },
 };
 
 // Alias used by index.ts (v2 API flow)
@@ -162,6 +224,15 @@ let importMenuTexts: Record<string, MenuText> = {
     completedText: "The category file has been successfully imported.",
     error: "Error",
     errorText: "An error occurred during import: ",
+  },
+  pt: {
+    action: "Importar arquivo de categoria",
+    actionText:
+      "Isso permitirá importar um arquivo de categoria CoMapeo (.comapeocat) ou arquivo de configuração Mapeo (.mapeosettings) para edição. AVISO: Isso apagará todos os dados atuais da planilha e os substituirá pelo conteúdo do arquivo. Continuar?",
+    completed: "Importação Concluída",
+    completedText: "O arquivo de categoria foi importado com sucesso.",
+    error: "Erro",
+    errorText: "Ocorreu um erro durante a importação: ",
   },
 };
 
@@ -188,5 +259,15 @@ let testExtractMenuTexts: Record<string, MenuText> = {
       "The extraction and validation test has completed successfully. Check the logs for detailed information.",
     error: "Error",
     errorText: "An error occurred during testing: ",
+  },
+  pt: {
+    action: "Testar extração e validação",
+    actionText:
+      "Isso fará o download de um arquivo de teste e executará o processo de extração e validação para diagnosticar problemas. Nenhum dado da planilha será modificado. Continuar?",
+    completed: "Teste Concluído",
+    completedText:
+      "O teste de extração e validação foi concluído com sucesso. Verifique os registros para informações detalhadas.",
+    error: "Erro",
+    errorText: "Ocorreu um erro durante o teste: ",
   },
 };


### PR DESCRIPTION
## Problem

The Spanish help dialog referenced sheet tab names `Categories` and `Details` in English without context. Spanish-speaking users might not know which sheets to edit.

In-code TODO at `src/text/dialog.ts:102`:
```typescript
// TODO: sheets shouls also be translated
```

## Fix

Added parenthetical Spanish translations after the English sheet names:

```diff
- "Edita las hojas llamadas Categories y Details para definir..."
+ "Edita las hojas llamadas Categories (categorías) y Details (detalles) para definir..."
```

The sheet tab names themselves remain in English (they are actual spreadsheet tab names), but now Spanish users have clear context about what they refer to.

Also removed the stale TODO comment.

Closes #38

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR clarifies English sheet tab names in the Spanish help dialog by adding parenthetical translations (`Categories (categorías)` / `Details (detalles)`), removes a stale TODO, and ships full Portuguese (`"pt"`) locale support across all menu and dialog text maps along with a `resolveLocale` safety helper in `src/dialog.ts`.

- **Spanish help dialog fix**: Parenthetical Spanish translations added for `Categories` and `Details` tab names; TODO comment removed.
- **Portuguese locale**: `"pt"` added to `supportedLocales` and complete translations provided for every menu, dialog, and processing-step text map.
- **`resolveLocale` guard**: New helper applied to all dialog functions in `src/dialog.ts` to fall back to `"en"` for any unsupported locale — but the inline `fixingDialogText` map in `src/generateCoMapeoConfig.ts` was not updated and has no `"pt"` entry, leaving one crash path unaddressed.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing one crash path in generateCoMapeoConfig.ts for Portuguese users.

The inline fixingDialogText map in src/generateCoMapeoConfig.ts has only en and es entries. Any Portuguese-locale user whose spreadsheet has translation mismatches and clicks YES to auto-fix them will receive undefined from fixingDialogText[pt], causing showProcessingModalDialog to throw mid-generation. Every other text map in the PR was given a complete pt entry, making this a straightforward oversight worth fixing before merge.

src/generateCoMapeoConfig.ts — the inline fixingDialogText map around line 61 needs a pt entry.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| index.ts | Adds "pt" to supportedLocales; straightforward one-line change. |
| src/dialog.ts | Introduces resolveLocale helper and applies it to all dialog functions that previously indexed directly with locale; fixes the previously reported crash surface for unsupported locales. |
| src/text/dialog.ts | Adds complete "pt" translation entries to all dialog text maps; also patches the Spanish help dialog to include parenthetical translations for sheet tab names and removes the stale TODO comment. |
| src/text/menu.ts | Adds "pt" entries to all menu text maps (translate, icon, category, debug, lint, clean, import, testExtract); all required fields are present. |
| src/generateCoMapeoConfig.ts | Inline fixingDialogText map has only en/es entries — no pt — so Portuguese users who choose to auto-fix translation mismatches will hit a TypeError crash here. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User opens spreadsheet] --> B{activeUserLocale}
    B -->|en / es / pt| C[activeLocale set]
    B -->|other| D[defaultLocale = en]
    C --> E{User action}
    D --> E

    E -->|Generate Category| F[generateCoMapeoConfig]
    E -->|Help| G[showHelpDialog]
    E -->|Import| H[importCategoryDialog]
    E -->|Translate| I[translateMenuTexts]

    F --> J{Translation mismatch?}
    J -->|No| K[processingDialogTexts resolveLocale]
    J -->|Yes, user clicks YES| L[fixingDialogText no pt entry]
    L -->|locale = pt| M[undefined - TypeError crash]

    G --> N[resolveLocale helpDialogTexts]
    H --> O[importCategoryDialogTexts pt entry exists]
    I --> P[translateMenuTexts pt entry exists]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/dialog.ts`, line 325-327 ([link](https://github.com/digidem/comapeo-category-spreadsheet-plugin/blob/65dc2b7998f3f3d0d53ca50c2b62f62a8bf21f8d/src/dialog.ts#L325-L327)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Missing "pt" entries crash several dialogs for Portuguese users**

   Adding "pt" to `supportedLocales` means `locale` will be `"pt"` for any Portuguese-locale GAS user. `showHelpDialog` received a safe fallback (`helpLocale = helpDialogTexts[locale] ? locale : "en"`), but the other dialog functions still index directly without a guard:

   - `iconDialogTexts[locale].title` (line 325) — no "pt" entry in `iconDialogTexts`
   - `generatedConfigDialogTexts[locale].title` (line 381) — no "pt" entry
   - `processingDialogTitle[locale]` (line 366) — no "pt" entry
   - `iconErrorDialogTexts[locale].title` (line 912) — no "pt" entry
   - `selectTranslationLanguagesDialogText[locale]` (line 430) — no "pt" entry

   Each of these returns `undefined` for "pt", and accessing a property on `undefined` throws a `TypeError` at runtime. Any Portuguese user who generates icons, triggers a category export, or opens the translate dialog will get a crash.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/dialog.ts
   Line: 325-327

   Comment:
   **Missing "pt" entries crash several dialogs for Portuguese users**

   Adding "pt" to `supportedLocales` means `locale` will be `"pt"` for any Portuguese-locale GAS user. `showHelpDialog` received a safe fallback (`helpLocale = helpDialogTexts[locale] ? locale : "en"`), but the other dialog functions still index directly without a guard:

   - `iconDialogTexts[locale].title` (line 325) — no "pt" entry in `iconDialogTexts`
   - `generatedConfigDialogTexts[locale].title` (line 381) — no "pt" entry
   - `processingDialogTitle[locale]` (line 366) — no "pt" entry
   - `iconErrorDialogTexts[locale].title` (line 912) — no "pt" entry
   - `selectTranslationLanguagesDialogText[locale]` (line 430) — no "pt" entry

   Each of these returns `undefined` for "pt", and accessing a property on `undefined` throws a `TypeError` at runtime. Any Portuguese user who generates icons, triggers a category export, or opens the translate dialog will get a crash.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (7): Last reviewed commit: ["fix: add locale fallback to all 6 dialog..."](https://github.com/digidem/comapeo-category-spreadsheet-plugin/commit/001b490389fee35e4d52a50a28eec395c6ac8fca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35356403)</sub>

<!-- /greptile_comment -->