### PR TITLE
feat: add 3-phase translation batching with cross-sheet cache

### DIFF
--- a/src/translation.ts
+++ b/src/translation.ts
@@ -189,6 +189,11 @@ function translateSheet(
  * standard languages. Validates all target languages before translation. Skips cells
  * that already have translations.
  *
+ * Uses a 3-phase approach for efficiency:
+ * 1. Collect all unique (sourceText, targetLang) pairs needing translation
+ * 2. Translate all unique texts using rate-limited API calls
+ * 3. Fill column values from cache
+ *
  * @param sheetName - Name of the sheet to translate
  * @param targetLanguages - Array of ISO language codes for target languages
  * @param sourceLanguage - Optional source language code (defaults to primary language)
@@ -319,7 +324,7 @@ function translateSheetBidirectional(
       `[Phase 1] Collected ${pendingTranslations.size} unique translations needed for ${sheetName}`,
     );
 
-    // Phase 2: Translate all unique texts
+    // Phase 2: Translate all unique texts (rate-limited)
     const prePhase2ErrorCount = translationErrors.length;
     let translateIndex = 0;
     for (const [cacheKey, { sourceText, targetLang }] of pendingTranslations) {


### PR DESCRIPTION
## Problem

`translateSheetBidirectional()` called `LanguageApp.translate()` per cell in a nested loop. If the same source text appeared in multiple rows (e.g., "Forest" in categories and options), it was translated multiple times. Across sheets, the same text was re-translated from scratch.

## Changes

### 3-phase refactor of `translateSheetBidirectional()`

**Phase 1 (Collect):** Scan all rows, build a deduplicated `Map` of unique `(sourceText, targetLang)` pairs needing translation. Skip pairs already in cache.

**Phase 2 (Translate):** Call `LanguageApp.translate()` once per unique pair only. Store results in cache.

**Phase 3 (Write):** Fill column values from cache. Batch-write each column in one operation.

### Cross-sheet translation cache

Added `crossSheetTranslationCache` — a module-level `Map<string, string>` that persists across all sheet translations in a single run. Cleared at the start of `autoTranslateSheetsBidirectional()`.

### Impact

- **Fewer API calls:** Same source text across rows is translated once per target language
- **Cross-sheet reuse:** "Forest" in Category Translations and Detail Option Translations = one translation total
- **No behavior changes:** Same translations produced, just more efficiently

Closes #39

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds JSDoc documentation and a minor inline comment update to `translateSheetBidirectional()`, describing the existing 3-phase batching approach (collect → translate → write) and cross-sheet cache already present in the codebase. The substantive logic — deduplication via `pendingTranslations`, the `crossSheetTranslationCache`, and the rate-limiter — was implemented prior to this diff; the diff only surfaces that context in the docstring.

- Added JSDoc block to `translateSheetBidirectional()` documenting the 3-phase efficiency strategy (unique-pair collection, rate-limited API calls, cache-backed writes).
- Updated the `// Phase 2` inline comment to note the rate-limiting behaviour, consistent with the surrounding code.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the diff is limited to documentation improvements with no logic changes.

The only changes are a new JSDoc block describing the existing 3-phase approach and a one-word addition to an inline comment. The underlying batching, deduplication, cross-sheet cache, and rate-limiting code is unchanged, and all previous review findings have been addressed in the current state of the file.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/translation.ts | Only documentation changes in the diff: new JSDoc phase description added and one inline comment updated. The underlying 3-phase batching and cross-sheet cache logic is unchanged and appears correct; prior review findings (cache `.clear()`, Phase 2 log wording, error context) have all been addressed. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller as autoTranslateSheetsBidirectional
    participant Cache as crossSheetTranslationCache
    participant Fn as translateSheetBidirectional
    participant API as LanguageApp.translate

    Caller->>Cache: clear()
    loop each translation sheet
        Caller->>Fn: translateSheetBidirectional(sheetName, targetLanguages)
        Note over Fn: Phase 1 – Collect
        Fn->>Cache: has(cacheKey)?
        alt not in cache
            Fn->>Fn: add to pendingTranslations
        end
        Note over Fn: Phase 2 – Translate (rate-limited)
        loop each pending unique pair
            Fn->>API: rateLimitedTranslate(text, src, target)
            API-->>Fn: translatedText
            Fn->>Cache: set(cacheKey, translation)
        end
        Note over Fn: Phase 3 – Write
        loop each row x target language
            Fn->>Cache: get(cacheKey)
            Cache-->>Fn: translation
            Fn->>Fn: update columnValues[rowIndex]
        end
        Fn->>Fn: batch setValues() per column
    end
```

<sub>Reviews (6): Last reviewed commit: ["feat: add 3-phase translation batching w..."](https://github.com/digidem/comapeo-category-spreadsheet-plugin/commit/bfd756dda743dcae998cdfb75c9f4acb9ed523ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35402319)</sub>

<!-- /greptile_comment -->