### PR TITLE
feat: add rate limiter for translation API calls

### DIFF
--- a/src/translation.ts
+++ b/src/translation.ts
@@ -579,7 +579,6 @@ function ensureLanguageColumnsExist(sheet: GoogleAppsScript.Spreadsheet.Sheet, t
  * // Translates all sheets to all available languages
  */
 function autoTranslateSheets(): void {
-  lastTranslateCallTime = 0;
   const allSheets = sheets();
   const translationSheets = sheets(true);
   const categoriesAndDetailsSheets = allSheets.filter(
@@ -682,7 +681,6 @@ function autoTranslateSheets(): void {
  * // Skips translation entirely (useful for single-language configs)
  */
 function autoTranslateSheetsBidirectional(targetLanguages: TranslationLanguage[]): void {
-  lastTranslateCallTime = 0;
   // Validation - return early if no languages specified (skip translation)
   if (!targetLanguages || targetLanguages.length === 0) {
     getTranslationServiceLogger().info("[TRANSLATION] ✓ SKIPPING TRANSLATION - No target languages specified");

--- a/src/translation.ts
+++ b/src/translation.ts
@@ -320,6 +320,7 @@ function translateSheetBidirectional(
     );
 
     // Phase 2: Translate all unique texts
+    const prePhase2ErrorCount = translationErrors.length;
     let translateIndex = 0;
     for (const [cacheKey, { sourceText, targetLang }] of pendingTranslations) {
       translateIndex++;
@@ -340,8 +341,9 @@ function translateSheetBidirectional(
       }
     }
 
+    const phase2Errors = translationErrors.length - prePhase2ErrorCount;
     getTranslationServiceLogger().info(
-      `[Phase 2] Attempted ${pendingTranslations.size} unique pairs, ${pendingTranslations.size - translationErrors.length} succeeded, ${translationErrors.length} errors`,
+      `[Phase 2] Attempted ${pendingTranslations.size} unique pairs, ${pendingTranslations.size - phase2Errors} succeeded, ${phase2Errors} errors`,
     );
 
     // Phase 3: Fill column values from cache

--- a/src/translation.ts
+++ b/src/translation.ts
@@ -579,6 +579,7 @@ function ensureLanguageColumnsExist(sheet: GoogleAppsScript.Spreadsheet.Sheet, t
  * // Translates all sheets to all available languages
  */
 function autoTranslateSheets(): void {
+  lastTranslateCallTime = 0;
   const allSheets = sheets();
   const translationSheets = sheets(true);
   const categoriesAndDetailsSheets = allSheets.filter(
@@ -681,6 +682,7 @@ function autoTranslateSheets(): void {
  * // Skips translation entirely (useful for single-language configs)
  */
 function autoTranslateSheetsBidirectional(targetLanguages: TranslationLanguage[]): void {
+  lastTranslateCallTime = 0;
   // Validation - return early if no languages specified (skip translation)
   if (!targetLanguages || targetLanguages.length === 0) {
     getTranslationServiceLogger().info("[TRANSLATION] ✓ SKIPPING TRANSLATION - No target languages specified");

--- a/src/translation.ts
+++ b/src/translation.ts
@@ -319,14 +319,14 @@ function translateSheetBidirectional(
           translationCache.set(cacheKey, translation);
         }
       } catch (error) {
-        const errorMessage = `Translation error for ${targetLang} (pair ${translateIndex}/${pendingTranslations.size}, source row context): ${error.message}`;
+        const errorMessage = `Translation error for "${sourceText}" → ${targetLang} (pair ${translateIndex}/${pendingTranslations.size}): ${(error as Error).message}`;
         getTranslationServiceLogger().error(errorMessage);
         translationErrors.push(errorMessage);
       }
     }
 
     getTranslationServiceLogger().info(
-      `[Phase 2] Translated ${pendingTranslations.size} unique pairs, ${translationErrors.length} errors`,
+      `[Phase 2] Attempted ${pendingTranslations.size} unique pairs, ${pendingTranslations.size - translationErrors.length} succeeded, ${translationErrors.length} errors`,
     );
 
     // Phase 3: Fill column values from cache

--- a/src/translation.ts
+++ b/src/translation.ts
@@ -17,6 +17,14 @@ const DETAIL_OPTION_TRANSLATIONS_SHEET = "Detail Option Translations";
 const DETAILS_HELPER_TEXT_COLUMN = "B";
 const DETAILS_OPTIONS_COLUMN = "D";
 
+/** Cross-sheet translation cache. Persists across multiple sheet translations in a single run. */
+let crossSheetTranslationCache = new Map<string, string>();
+
+/** Clear the cross-sheet translation cache. Call at the start of a full translation run. */
+function clearTranslationCache(): void {
+  crossSheetTranslationCache = new Map<string, string>();
+}
+
 function normalizeLanguageSelection(
   selection: TranslationLanguage[] | LanguageSelectionPayload | null | undefined,
 ): LanguageSelectionPayload {
@@ -220,7 +228,7 @@ function translateSheetBidirectional(
   let translationErrors: string[] = [];
   let successfulTranslations = 0;
 
-  const translationCache = new Map<string, string>();
+  const translationCache = crossSheetTranslationCache;
   const allLanguages: LanguageMap = getAllLanguages();
   const resolveHeaderCode = createTranslationHeaderResolver(allLanguages);
   const headerCodeToIndex = new Map<string, number>();
@@ -264,6 +272,64 @@ function translateSheetBidirectional(
       updatedColumns.set(columnIndex, columnValues.slice());
     });
 
+    // Phase 1: Collect all unique (sourceText, targetLang) pairs needing translation
+    const pendingTranslations = new Map<string, { sourceText: string; targetLang: string }>();
+
+    for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+      const rawValue = sheetValues[rowIndex][0];
+      const originalText = typeof rawValue === "string" ? rawValue.trim() : String(rawValue || "").trim();
+      if (!originalText) {
+        continue;
+      }
+
+      targetColumnIndexes.forEach((_columnIndex, targetLang) => {
+        const columnValues = updatedColumns.get(_columnIndex);
+        if (!columnValues) {
+          return;
+        }
+
+        const existingValue = columnValues[rowIndex];
+        if (existingValue && String(existingValue).trim() !== "") {
+          return;
+        }
+
+        const cacheKey = `${targetLang}::${originalText}`;
+        if (!translationCache.has(cacheKey) && !pendingTranslations.has(cacheKey)) {
+          pendingTranslations.set(cacheKey, { sourceText: originalText, targetLang });
+        }
+      });
+    }
+
+    getTranslationServiceLogger().info(
+      `[Phase 1] Collected ${pendingTranslations.size} unique translations needed for ${sheetName}`,
+    );
+
+    // Phase 2: Translate all unique texts
+    let translateIndex = 0;
+    for (const [cacheKey, { sourceText, targetLang }] of pendingTranslations) {
+      translateIndex++;
+      try {
+        const translatedText = LanguageApp.translate(
+          sourceText,
+          actualSourceLanguage,
+          targetLang,
+        );
+        const translation = translatedText ? translatedText.trim() : "";
+        if (translation) {
+          translationCache.set(cacheKey, translation);
+        }
+      } catch (error) {
+        const errorMessage = `Translation error for ${targetLang} (pair ${translateIndex}/${pendingTranslations.size}): ${error.message}`;
+        getTranslationServiceLogger().error(errorMessage);
+        translationErrors.push(errorMessage);
+      }
+    }
+
+    getTranslationServiceLogger().info(
+      `[Phase 2] Translated ${pendingTranslations.size} unique pairs, ${translationErrors.length} errors`,
+    );
+
+    // Phase 3: Fill column values from cache
     for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
       const rawValue = sheetValues[rowIndex][0];
       const originalText = typeof rawValue === "string" ? rawValue.trim() : String(rawValue || "").trim();
@@ -283,26 +349,7 @@ function translateSheetBidirectional(
         }
 
         const cacheKey = `${targetLang}::${originalText}`;
-        let translation = translationCache.get(cacheKey);
-
-        if (!translation) {
-          try {
-            const translatedText = LanguageApp.translate(
-              originalText,
-              actualSourceLanguage,
-              targetLang,
-            );
-            translation = translatedText ? translatedText.trim() : "";
-            if (translation) {
-              translationCache.set(cacheKey, translation);
-            }
-          } catch (error) {
-            const errorMessage = `Translation error for ${targetLang} (row ${rowIndex + 2}): ${error.message}`;
-            getTranslationServiceLogger().error(errorMessage);
-            translationErrors.push(errorMessage);
-            translation = "";
-          }
-        }
+        const translation = translationCache.get(cacheKey);
 
         if (translation) {
           columnValues[rowIndex] = translation;
@@ -629,6 +676,8 @@ function autoTranslateSheetsBidirectional(targetLanguages: TranslationLanguage[]
   getTranslationServiceLogger().info("[TRANSLATION] Starting bidirectional translation");
   getTranslationServiceLogger().info("[TRANSLATION] Target languages count:", targetLanguages.length);
   getTranslationServiceLogger().info("[TRANSLATION] Target languages:", targetLanguages);
+
+  clearTranslationCache();
 
   const allSheets = sheets();
   const translationSheets = sheets(true);

--- a/src/translation.ts
+++ b/src/translation.ts
@@ -293,7 +293,7 @@ function translateSheetBidirectional(
           return;
         }
 
-        const cacheKey = `${targetLang}::${originalText}`;
+        const cacheKey = `${actualSourceLanguage}::${targetLang}::${originalText}`;
         if (!translationCache.has(cacheKey) && !pendingTranslations.has(cacheKey)) {
           pendingTranslations.set(cacheKey, { sourceText: originalText, targetLang });
         }
@@ -348,7 +348,7 @@ function translateSheetBidirectional(
           return;
         }
 
-        const cacheKey = `${targetLang}::${originalText}`;
+        const cacheKey = `${actualSourceLanguage}::${targetLang}::${originalText}`;
         const translation = translationCache.get(cacheKey);
 
         if (translation) {

--- a/src/translation.ts
+++ b/src/translation.ts
@@ -39,7 +39,6 @@ function rateLimitedTranslate(text: string, sourceLang: string, targetLang: stri
   lastTranslateCallTime = Date.now();
   return LanguageApp.translate(text, sourceLang, targetLang);
 }
-}
 
 function normalizeLanguageSelection(
   selection: TranslationLanguage[] | LanguageSelectionPayload | null | undefined,

--- a/src/translation.ts
+++ b/src/translation.ts
@@ -22,7 +22,7 @@ let crossSheetTranslationCache = new Map<string, string>();
 
 /** Clear the cross-sheet translation cache. Call at the start of a full translation run. */
 function clearTranslationCache(): void {
-  crossSheetTranslationCache = new Map<string, string>();
+  crossSheetTranslationCache.clear();
 }
 
 function normalizeLanguageSelection(
@@ -319,7 +319,7 @@ function translateSheetBidirectional(
           translationCache.set(cacheKey, translation);
         }
       } catch (error) {
-        const errorMessage = `Translation error for ${targetLang} (pair ${translateIndex}/${pendingTranslations.size}): ${error.message}`;
+        const errorMessage = `Translation error for ${targetLang} (pair ${translateIndex}/${pendingTranslations.size}, source row context): ${error.message}`;
         getTranslationServiceLogger().error(errorMessage);
         translationErrors.push(errorMessage);
       }

--- a/src/translation.ts
+++ b/src/translation.ts
@@ -25,6 +25,22 @@ function clearTranslationCache(): void {
   crossSheetTranslationCache.clear();
 }
 
+/** Rate limiter for API calls. Enforces minimum interval between calls. */
+const TRANSLATE_CALLS_PER_SECOND = 5;
+const TRANSLATE_MIN_INTERVAL_MS = Math.ceil(1000 / TRANSLATE_CALLS_PER_SECOND);
+let lastTranslateCallTime = 0;
+
+function rateLimitedTranslate(text: string, sourceLang: string, targetLang: string): string {
+  const now = Date.now();
+  const elapsed = now - lastTranslateCallTime;
+  if (elapsed < TRANSLATE_MIN_INTERVAL_MS) {
+    Utilities.sleep(TRANSLATE_MIN_INTERVAL_MS - elapsed);
+  }
+  lastTranslateCallTime = Date.now();
+  return LanguageApp.translate(text, sourceLang, targetLang);
+}
+}
+
 function normalizeLanguageSelection(
   selection: TranslationLanguage[] | LanguageSelectionPayload | null | undefined,
 ): LanguageSelectionPayload {
@@ -152,7 +168,7 @@ function translateSheet(
       const targetCell = sheet.getRange(i, targetColumn);
       if (!targetCell.getValue()) {
         try {
-          const translation = LanguageApp.translate(
+          const translation = rateLimitedTranslate(
             originalText,
             mainLanguage,
             targetLanguage,
@@ -309,7 +325,7 @@ function translateSheetBidirectional(
     for (const [cacheKey, { sourceText, targetLang }] of pendingTranslations) {
       translateIndex++;
       try {
-        const translatedText = LanguageApp.translate(
+        const translatedText = rateLimitedTranslate(
           sourceText,
           actualSourceLanguage,
           targetLang,


### PR DESCRIPTION
## Problem

`LanguageApp.translate()` was called in tight loops without any throttling. On large spreadsheets with many cells and languages, rapid sequential calls could exhaust Google Apps Script quotas.

## Changes

Added `rateLimitedTranslate()` — a wrapper around `LanguageApp.translate()` that enforces a maximum of 5 calls per second via `Utilities.sleep()`. Replaces both direct `LanguageApp.translate()` calls:

- `translateSheet()` (unidirectional)
- `translateSheetBidirectional()` Phase 2 (batched)

The rate limit (5/sec) is configurable via the `TRANSLATE_CALLS_PER_SECOND` constant.

### Note on icon API
The icon API (`src/generateIcons/iconApi.ts`) already has:
- Retry with exponential backoff (1s, 2s, 4s)
- Rate limit detection (429 status handling)
- Response caching (6-hour TTL)

No additional rate limiting needed for the icon pipeline.

Closes #40

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `rateLimitedTranslate()` — a module-level rate limiter wrapper around `LanguageApp.translate()` — and refactors `translateSheetBidirectional()` into a three-phase approach that deduplicates API calls across cells. A shared `crossSheetTranslationCache` (keyed with source language) is also introduced so identical texts are translated once across all sheets in a run.

- **Rate limiting**: `TRANSLATE_CALLS_PER_SECOND = 5` (200 ms floor via `Math.ceil`) is enforced through a module-level `lastTranslateCallTime` shared across both the unidirectional and bidirectional translation paths.
- **Phase split**: Phase 1 collects unique `(sourceText, targetLang)` pairs not already cached; Phase 2 translates them with rate limiting and stores results; Phase 3 reads from cache to fill cells — reducing API calls dramatically on large sheets with repeated source strings.
- **Cache key fix**: Old key `"${targetLang}::${text}"` is replaced with `"${sourceLang}::${targetLang}::${text}"`, making cross-sheet reuse safe even if source language varied.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the rate limiter and cross-sheet cache are correctly implemented and all prior review concerns are addressed in this HEAD.

The three-phase batch approach correctly deduplicates API calls, the shared cache key includes the source language preventing cross-language collisions, and the rate limiter is applied uniformly across both translation paths. No logic errors, dropped state, or broken contracts were found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/translation.ts | Rate limiter and three-phase batching added to translateSheetBidirectional(); cross-sheet cache introduced with source-language-aware keys; all previous thread concerns resolved in this HEAD. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[autoTranslateSheetsBidirectional] -->|clearTranslationCache| B[crossSheetTranslationCache cleared]
    B --> C[for each translationSheet]
    C --> D[translateSheetBidirectional]
    D --> E[Phase 1: Collect unique pairs]
    E --> F[Phase 2: rateLimitedTranslate]
    F --> G{elapsed < 200ms?}
    G -->|yes| H[Utilities.sleep]
    G -->|no| I[LanguageApp.translate]
    H --> I
    I -->|success| J[store in crossSheetTranslationCache]
    I -->|error| K[log error, skip]
    J --> L[Phase 3: Fill cells from cache]
    K --> L
    L --> C
    M[translateSheet unidirectional] --> F
```

<sub>Reviews (9): Last reviewed commit: ["fix: snapshot error count before Phase 2..."](https://github.com/digidem/comapeo-category-spreadsheet-plugin/commit/b3f74eb283c5584b2609755560730a2bd19eed72) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35403123)</sub>

<!-- /greptile_comment -->