### PR TITLE
feat: add JSON schema validation on .comapeocat import

### DIFF
--- a/src/importCategory.ts
+++ b/src/importCategory.ts
@@ -97,6 +97,12 @@ function processImportedCategoryFile(
       }
     }
 
+    // Collect all warnings: extraction + config validation
+    const allWarnings = [
+      ...(extractionResult.validationWarnings || []),
+      ...(configData._validationWarnings || []),
+    ];
+
     return {
       success: true,
       message: "Category file imported successfully",
@@ -106,7 +112,7 @@ function processImportedCategoryFile(
         icons: configData.icons.length,
         languages: Object.keys(configData.messages).length,
       },
-      warnings: extractionResult.validationWarnings || [],
+      warnings: allWarnings,
     };
   } catch (error) {
     getScopedLogger("ImportCategory").error("Error processing imported file:", error);

--- a/src/importCategory/extractPngIcons.ts
+++ b/src/importCategory/extractPngIcons.ts
@@ -59,7 +59,7 @@ function updateDriveFileBlobInPlace(
  */
 function extractPngIcons(
   tempFolder: GoogleAppsScript.Drive.Folder,
-  presets: any[],
+  presets: ImportedPreset[],
   onProgress?: (update: { percent: number; stage: string; detail?: string }) => void,
 ): { name: string; svg: string; id: string }[] {
   try {

--- a/src/importCategory/importProgressHandler.ts
+++ b/src/importCategory/importProgressHandler.ts
@@ -192,6 +192,12 @@ function processImportedCategoryFileWithProgress(
       console.warn("Failed to finalize debug logging:", error);
     }
 
+    // Collect all warnings: extraction + config validation
+    const allWarnings = [
+      ...(extractionResult.validationWarnings || []),
+      ...(configData._validationWarnings || []),
+    ];
+
     return {
       success: true,
       message: "Configuration file imported successfully",
@@ -202,7 +208,7 @@ function processImportedCategoryFileWithProgress(
         languages: Object.keys(configData.messages),
         processingTime: processingTime,
       },
-      warnings: extractionResult.validationWarnings || [],
+      warnings: allWarnings,
     };
   } catch (error) {
     console.error("Error in processImportedCategoryFileWithProgress:", error);

--- a/src/importCategory/parseFiles.ts
+++ b/src/importCategory/parseFiles.ts
@@ -584,5 +584,16 @@ function parseExtractedFiles(
 	delete configData.iconsPngFile;
 	delete configData.iconsJsonFile;
 
+	// Validate the parsed configuration before returning
+	const validation = validateImportedConfig(configData);
+	if (!validation.valid) {
+		getScopedLogger("ParseFiles").warn(
+			`Imported config validation warnings: ${validation.errors.join("; ")}`,
+		);
+		// Don't fail the import — just warn. Some fields may be optional.
+	} else {
+		getScopedLogger("ParseFiles").info("Imported config passed validation");
+	}
+
 	return configData;
 }

--- a/src/importCategory/parseFiles.ts
+++ b/src/importCategory/parseFiles.ts
@@ -68,9 +68,12 @@ function restructureTranslations(flatMessages: Record<string, unknown>): Record<
 		if (!source || typeof source !== "object") {
 			return;
 		}
-		container.options = container.options || {};
+		const existingOptions = container.options && typeof container.options === "object"
+			? container.options as Record<string, unknown>
+			: {};
+		container.options = existingOptions;
 		for (const [optionId, optionValue] of Object.entries(source)) {
-			container.options[optionId] = normalizeOption(optionValue, optionId);
+			existingOptions[optionId] = normalizeOption(optionValue, optionId);
 		}
 	};
 
@@ -121,6 +124,7 @@ function restructureTranslations(flatMessages: Record<string, unknown>): Record<
 			getScopedLogger("ParseFiles").warn(`Invalid messages for language: ${lang}`);
 			continue;
 		}
+		const langObj = langMessages as Record<string, unknown>;
 
 		const langResult = {
 			presets: {
@@ -129,13 +133,15 @@ function restructureTranslations(flatMessages: Record<string, unknown>): Record<
 			},
 		};
 
+		const rawPresets = langObj.presets;
+		const rawFields = langObj.fields;
 		const nestedPresets =
-			langMessages?.presets && typeof langMessages.presets === "object"
-				? langMessages.presets
+			rawPresets && typeof rawPresets === "object"
+				? rawPresets as Record<string, unknown>
 				: undefined;
 		const nestedFields =
-			langMessages?.fields && typeof langMessages.fields === "object"
-				? langMessages.fields
+			rawFields && typeof rawFields === "object"
+				? rawFields as Record<string, unknown>
 				: undefined;
 
 		if (nestedPresets) {
@@ -181,7 +187,7 @@ function restructureTranslations(flatMessages: Record<string, unknown>): Record<
 			}
 		}
 
-		for (const [rawKey, rawValue] of Object.entries(langMessages)) {
+		for (const [rawKey, rawValue] of Object.entries(langObj)) {
 			if (typeof rawKey !== "string" || !rawKey.includes(".")) {
 				continue;
 			}

--- a/src/importCategory/parseFiles.ts
+++ b/src/importCategory/parseFiles.ts
@@ -317,7 +317,10 @@ function parseExtractedFiles(
 					) {
 						for (const fieldId in content.fields) {
 							const rawField = content.fields[fieldId];
-							if (!rawField || typeof rawField !== "object") continue;
+							if (!rawField || typeof rawField !== "object") {
+								getScopedLogger("ParseFiles").warn(`Skipping invalid field entry '${fieldId}' (not an object)`);
+								continue;
+							}
 							const field = rawField as Record<string, unknown>;
 
 							// Convert field type

--- a/src/importCategory/parseFiles.ts
+++ b/src/importCategory/parseFiles.ts
@@ -337,13 +337,13 @@ function parseExtractedFiles(
 							const field = rawField as Record<string, unknown>;
 
 							// Convert field type
-							let fieldType = "text";
+							let fieldType: FieldType = "text";
 							if (field.type === "select_one") fieldType = "selectOne";
 							else if (field.type === "select_multiple")
 								fieldType = "selectMultiple";
 
 						// Convert options
-						let options = [];
+						let options: { label: string; value: string }[] = [];
 						if (field.options) {
 							if (Array.isArray(field.options)) {
 								// Handle array of strings or objects

--- a/src/importCategory/parseFiles.ts
+++ b/src/importCategory/parseFiles.ts
@@ -316,7 +316,9 @@ function parseExtractedFiles(
 						!Array.isArray(content.fields)
 					) {
 						for (const fieldId in content.fields) {
-							const field = content.fields[fieldId];
+							const rawField = content.fields[fieldId];
+							if (!rawField || typeof rawField !== "object") continue;
+							const field = rawField as Record<string, unknown>;
 
 							// Convert field type
 							let fieldType = "text";
@@ -366,10 +368,10 @@ function parseExtractedFiles(
 					configData.fields.push({
 						id: fieldId,
 						tagKey: fieldId,
-						label: field.label || fieldId,
+						label: String(field.label || fieldId),
 						type: fieldType,
-						helperText: field.helperText || field.placeholder || "",
-						placeholder: field.placeholder || field.helperText || "",
+						helperText: String(field.helperText || field.placeholder || ""),
+						placeholder: String(field.placeholder || field.helperText || ""),
 						options: options,
 					});
 						}

--- a/src/importCategory/parseFiles.ts
+++ b/src/importCategory/parseFiles.ts
@@ -15,13 +15,13 @@
  * @param flatMessages - Messages object with flat key structure
  * @returns Messages object with nested structure
  */
-function restructureTranslations(flatMessages: any): any {
+function restructureTranslations(flatMessages: Record<string, unknown>): Record<string, TranslationLocaleData> {
 	if (!flatMessages || typeof flatMessages !== "object") {
 		getScopedLogger("ParseFiles").warn("Invalid flatMessages object, returning empty structure");
 		return {};
 	}
 
-	const toScalar = (input: any, fallback: string): string => {
+	const toScalar = (input: unknown, fallback: string): string => {
 		if (input === undefined || input === null) {
 			return fallback;
 		}
@@ -47,7 +47,7 @@ function restructureTranslations(flatMessages: any): any {
 		}
 	};
 
-	const normalizeOption = (rawValue: any, optionId: string) => {
+	const normalizeOption = (rawValue: unknown, optionId: string) => {
 		const label = toScalar(rawValue, "");
 		let value = optionId;
 		if (rawValue && typeof rawValue === "object") {
@@ -62,8 +62,8 @@ function restructureTranslations(flatMessages: any): any {
 	};
 
 	const mergeOptionMap = (
-		container: Record<string, any>,
-		source: Record<string, any>,
+		container: Record<string, unknown>,
+		source: Record<string, unknown>,
 	) => {
 		if (!source || typeof source !== "object") {
 			return;
@@ -75,22 +75,22 @@ function restructureTranslations(flatMessages: any): any {
 	};
 
 	const mergeScalarProps = (
-		target: Record<string, any>,
-		source: Record<string, any>,
+		target: Record<string, unknown>,
+		source: Record<string, unknown>,
 	) => {
 		if (!source || typeof source !== "object") {
 			return;
 		}
 		for (const [prop, value] of Object.entries(source)) {
 			if (prop === "options") {
-				mergeOptionMap(target, value as Record<string, any>);
+				mergeOptionMap(target, value as Record<string, unknown>);
 			} else if (value !== undefined) {
 				target[prop] = toScalar(value, "");
 			}
 		}
 	};
 
-	const hasTranslationValue = (input: any): boolean => {
+	const hasTranslationValue = (input: unknown): boolean => {
 		if (typeof input === "string") {
 			return input.trim() !== "";
 		}
@@ -113,7 +113,7 @@ function restructureTranslations(flatMessages: any): any {
 		return false;
 	};
 
-	const restructured: any = {};
+	const restructured: Record<string, TranslationLocaleData> = {};
 
 	for (const lang of Object.keys(flatMessages)) {
 		const langMessages = flatMessages[lang];
@@ -124,8 +124,8 @@ function restructureTranslations(flatMessages: any): any {
 
 		const langResult = {
 			presets: {
-				presets: {} as Record<string, any>,
-				fields: {} as Record<string, any>,
+				presets: {} as Record<string, TranslationPreset>,
+				fields: {} as Record<string, TranslationField>,
 			},
 		};
 
@@ -142,21 +142,20 @@ function restructureTranslations(flatMessages: any): any {
 			if (nestedPresets.presets && typeof nestedPresets.presets === "object") {
 				for (const [presetId, presetValue] of Object.entries(nestedPresets.presets)) {
 					const targetPreset = langResult.presets.presets[presetId] || {};
-					mergeScalarProps(targetPreset, presetValue as Record<string, any>);
+					mergeScalarProps(targetPreset, presetValue as Record<string, unknown>);
 					langResult.presets.presets[presetId] = targetPreset;
 				}
 			}
 			if (nestedPresets.categories && typeof nestedPresets.categories === "object") {
 				for (const [presetId, presetValue] of Object.entries(nestedPresets.categories)) {
 					const targetPreset = langResult.presets.presets[presetId] || {};
-					mergeScalarProps(targetPreset, presetValue as Record<string, any>);
-					langResult.presets.presets[presetId] = targetPreset;
+					mergeScalarProps(targetPreset, presetValue as Record<string, unknown>);
 				}
 			}
 			if (nestedPresets.fields && typeof nestedPresets.fields === "object") {
 				for (const [fieldId, fieldValue] of Object.entries(nestedPresets.fields)) {
 					const targetField = langResult.presets.fields[fieldId] || {};
-					mergeScalarProps(targetField, fieldValue as Record<string, any>);
+					mergeScalarProps(targetField, fieldValue as Record<string, unknown>);
 					langResult.presets.fields[fieldId] = targetField;
 				}
 			}
@@ -168,15 +167,14 @@ function restructureTranslations(flatMessages: any): any {
 					continue;
 				}
 				const targetPreset = langResult.presets.presets[maybePresetId] || {};
-				mergeScalarProps(targetPreset, presetValue as Record<string, any>);
-				langResult.presets.presets[maybePresetId] = targetPreset;
+				mergeScalarProps(targetPreset, presetValue as Record<string, unknown>);
 			}
 		}
 
 		if (nestedFields) {
 			for (const [fieldId, fieldValue] of Object.entries(nestedFields)) {
 				const targetField = langResult.presets.fields[fieldId] || {};
-				mergeScalarProps(targetField, fieldValue as Record<string, any>);
+				mergeScalarProps(targetField, fieldValue as Record<string, unknown>);
 				langResult.presets.fields[fieldId] = targetField;
 			}
 		}
@@ -191,7 +189,7 @@ function restructureTranslations(flatMessages: any): any {
 			}
 			const messageValue =
 				typeof rawValue === "object" && rawValue !== null && "message" in rawValue
-					? (rawValue as any).message
+					? (rawValue as { message: unknown }).message
 					: rawValue;
 
 			if (parts[0] === "presets") {
@@ -247,7 +245,7 @@ function parseExtractedFiles(
 	files: GoogleAppsScript.Base.Blob[] | undefined,
 	tempFolder: GoogleAppsScript.Drive.Folder,
 	onProgress?: (update: { percent: number; stage: string; detail?: string }) => void,
-): any {
+): ImportedConfig {
 	// Handle undefined or empty files array
 	if (!files || !Array.isArray(files)) {
 		getScopedLogger("ParseFiles").info("No files to parse or files is not an array");
@@ -263,7 +261,7 @@ function parseExtractedFiles(
 	getScopedLogger("ParseFiles").info(`Parsing ${files.length} extracted files...`);
 
 	// Initialize configuration data
-	const configData: any = {
+	const configData: ImportedConfig = {
 		metadata: null,
 		presets: [],
 		fields: [],
@@ -329,7 +327,7 @@ function parseExtractedFiles(
 						if (field.options) {
 							if (Array.isArray(field.options)) {
 								// Handle array of strings or objects
-								options = field.options.map((opt: any, optionIndex: number) => {
+								options = field.options.map((opt: unknown, optionIndex: number) => {
 									if (typeof opt === "string") {
 										return {
 											label: opt,

--- a/src/importCategory/parseFiles.ts
+++ b/src/importCategory/parseFiles.ts
@@ -309,6 +309,13 @@ function parseExtractedFiles(
 								icon: preset.icon || presetId,
 								color: preset.color || "#0000FF",
 								fields: preset.fields || [],
+								appliesTo: preset.appliesTo || ["observation"],
+								tags: preset.tags || { type: presetId },
+								addTags: preset.addTags,
+								removeTags: preset.removeTags,
+								terms: preset.terms || [],
+								geometry: preset.geometry,
+								sort: preset.sort,
 							});
 						}
 					}

--- a/src/importCategory/parseFiles.ts
+++ b/src/importCategory/parseFiles.ts
@@ -593,14 +593,15 @@ function parseExtractedFiles(
 
 	// Validate the parsed configuration before returning
 	const validation = validateImportedConfig(configData);
-	if (!validation.valid) {
-		getScopedLogger("ParseFiles").warn(
+	const logger = getScopedLogger("ParseFiles");
+	if (!validation.isValid) {
+		logger.warn(
 			`Imported config validation warnings: ${validation.errors.join("; ")}`,
 		);
 		// Attach warnings so callers can surface them to the user
 		configData._validationWarnings = validation.errors;
 	} else {
-		getScopedLogger("ParseFiles").info("Imported config passed validation");
+		logger.info("Imported config passed validation");
 	}
 
 	return configData;

--- a/src/importCategory/parseFiles.ts
+++ b/src/importCategory/parseFiles.ts
@@ -591,7 +591,7 @@ function parseExtractedFiles(
 			`Imported config validation warnings: ${validation.errors.join("; ")}`,
 		);
 		// Attach warnings so callers can surface them to the user
-		(configData as Record<string, unknown>)._validationWarnings = validation.errors;
+		configData._validationWarnings = validation.errors;
 	} else {
 		getScopedLogger("ParseFiles").info("Imported config passed validation");
 	}

--- a/src/importCategory/parseFiles.ts
+++ b/src/importCategory/parseFiles.ts
@@ -150,6 +150,7 @@ function restructureTranslations(flatMessages: Record<string, unknown>): Record<
 				for (const [presetId, presetValue] of Object.entries(nestedPresets.categories)) {
 					const targetPreset = langResult.presets.presets[presetId] || {};
 					mergeScalarProps(targetPreset, presetValue as Record<string, unknown>);
+					langResult.presets.presets[presetId] = targetPreset;
 				}
 			}
 			if (nestedPresets.fields && typeof nestedPresets.fields === "object") {
@@ -168,6 +169,7 @@ function restructureTranslations(flatMessages: Record<string, unknown>): Record<
 				}
 				const targetPreset = langResult.presets.presets[maybePresetId] || {};
 				mergeScalarProps(targetPreset, presetValue as Record<string, unknown>);
+				langResult.presets.presets[maybePresetId] = targetPreset;
 			}
 		}
 
@@ -334,10 +336,11 @@ function parseExtractedFiles(
 											value: createOptionValue(opt, fieldId, optionIndex),
 										};
 									} else if (typeof opt === "object" && opt !== null) {
-										const optionLabel = opt.label || opt.value || opt.name || String(opt);
+										const obj = opt as Record<string, unknown>;
+										const optionLabel = String(obj.label || obj.value || obj.name || opt);
 										const normalizedValue =
-											typeof opt.value === "string" && opt.value.trim() !== ""
-												? opt.value
+											typeof obj.value === "string" && obj.value.trim() !== ""
+												? obj.value
 											: createOptionValue(optionLabel, fieldId, optionIndex);
 										return {
 											label: optionLabel,

--- a/src/importCategory/parseFiles.ts
+++ b/src/importCategory/parseFiles.ts
@@ -590,7 +590,8 @@ function parseExtractedFiles(
 		getScopedLogger("ParseFiles").warn(
 			`Imported config validation warnings: ${validation.errors.join("; ")}`,
 		);
-		// Don't fail the import — just warn. Some fields may be optional.
+		// Attach warnings so callers can surface them to the user
+		(configData as Record<string, unknown>)._validationWarnings = validation.errors;
 	} else {
 		getScopedLogger("ParseFiles").info("Imported config passed validation");
 	}

--- a/src/importCategory/validateConfig.ts
+++ b/src/importCategory/validateConfig.ts
@@ -69,6 +69,14 @@ function validateImportedConfig(config: unknown): { valid: boolean; errors: stri
     }
   }
 
+  // Check for completely empty config (all required arrays empty)
+  const presetsArr = Array.isArray(cfg.presets) ? cfg.presets : [];
+  const fieldsArr = Array.isArray(cfg.fields) ? cfg.fields : [];
+  const iconsArr = Array.isArray(cfg.icons) ? cfg.icons : [];
+  if (presetsArr.length === 0 && fieldsArr.length === 0 && iconsArr.length === 0) {
+    errors.push("Configuration appears empty — no presets, fields, or icons found");
+  }
+
   return {
     valid: errors.length === 0,
     errors,

--- a/src/importCategory/validateConfig.ts
+++ b/src/importCategory/validateConfig.ts
@@ -1,9 +1,18 @@
 /** Maximum number of validation errors to report. Prevents memory issues on corrupt archives. */
 const MAX_VALIDATION_ERRORS = 20;
 
+/** Valid document types per CoMapeo spec */
+const VALID_DOCUMENT_TYPES = ["observation", "track"];
+
+/** Valid field types per CoMapeo spec */
+const VALID_FIELD_TYPES = ["text", "number", "selectOne", "selectMultiple"];
+
 /**
  * Validates the structure of imported configuration data before applying to spreadsheet.
  * Catches malformed .comapeocat files early with clear error messages.
+ *
+ * Checks conform to the canonical CoMapeo category schema defined in
+ * `package/src/schema/category.js` and `package/src/schema/field.js`.
  *
  * @param config - The parsed configuration object to validate
  * @returns Object with valid flag and array of error messages
@@ -44,8 +53,29 @@ function validateImportedConfig(config: unknown): { valid: boolean; errors: stri
         continue;
       }
       const p = preset as Record<string, unknown>;
+
+      // name is required
       if (typeof p.name !== "string" || !p.name.trim()) {
-        errors.push(`Preset at index ${i} missing 'name' property`);
+        errors.push(`Preset '${p.id || `index ${i}`}' missing required 'name' property`);
+      }
+
+      // appliesTo is required per spec
+      if (!Array.isArray(p.appliesTo) || p.appliesTo.length === 0) {
+        errors.push(`Preset '${p.name || `index ${i}`}' missing required 'appliesTo' array (expected ['observation'] and/or ['track'])`);
+      } else {
+        const invalidTypes = (p.appliesTo as string[]).filter(
+          (t) => !VALID_DOCUMENT_TYPES.includes(t),
+        );
+        if (invalidTypes.length > 0 && errors.length < MAX_VALIDATION_ERRORS) {
+          errors.push(`Preset '${p.name || `index ${i}`}' has unrecognized appliesTo values: ${invalidTypes.join(", ")}`);
+        }
+      }
+
+      // tags is required per spec (must be non-empty object)
+      if (!p.tags || typeof p.tags !== "object" || Array.isArray(p.tags) || Object.keys(p.tags as Record<string, unknown>).length === 0) {
+        if (errors.length < MAX_VALIDATION_ERRORS) {
+          errors.push(`Preset '${p.name || `index ${i}`}' missing required 'tags' object (must have at least one entry)`);
+        }
       }
     }
   }
@@ -59,8 +89,24 @@ function validateImportedConfig(config: unknown): { valid: boolean; errors: stri
         continue;
       }
       const f = field as Record<string, unknown>;
+
+      // label is required
       if (typeof f.label !== "string" || !f.label.trim()) {
-        errors.push(`Field at index ${i} missing 'label' property`);
+        errors.push(`Field '${f.id || `index ${i}`}' missing required 'label' property`);
+      }
+
+      // tagKey is required per spec
+      if (typeof f.tagKey !== "string" || !f.tagKey.trim()) {
+        if (errors.length < MAX_VALIDATION_ERRORS) {
+          errors.push(`Field '${f.id || `index ${i}`}' missing required 'tagKey' property`);
+        }
+      }
+
+      // type should be a valid enum value
+      if (f.type !== undefined && !VALID_FIELD_TYPES.includes(f.type as string)) {
+        if (errors.length < MAX_VALIDATION_ERRORS) {
+          errors.push(`Field '${f.id || `index ${i}`}' has unrecognized type '${f.type}' (expected one of: ${VALID_FIELD_TYPES.join(", ")})`);
+        }
       }
     }
   }
@@ -86,9 +132,9 @@ function validateImportedConfig(config: unknown): { valid: boolean; errors: stri
     }
   }
 
-  // Add summary if errors were capped (replace last error to stay within cap)
+  // Add summary if errors were capped — push the summary so no real error is silently dropped
   if (errors.length >= MAX_VALIDATION_ERRORS) {
-    errors[MAX_VALIDATION_ERRORS - 1] = `... and more issues may exist (showing first ${MAX_VALIDATION_ERRORS - 1})`;
+    errors.push(`... and more issues may exist (showing first ${MAX_VALIDATION_ERRORS})`);
   }
 
   return {

--- a/src/importCategory/validateConfig.ts
+++ b/src/importCategory/validateConfig.ts
@@ -69,12 +69,16 @@ function validateImportedConfig(config: unknown): { valid: boolean; errors: stri
     }
   }
 
-  // Check for completely empty config (all required arrays empty)
+  // Check for completely empty config (no data at all)
   const presetsArr = Array.isArray(cfg.presets) ? cfg.presets : [];
   const fieldsArr = Array.isArray(cfg.fields) ? cfg.fields : [];
   const iconsArr = Array.isArray(cfg.icons) ? cfg.icons : [];
-  if (presetsArr.length === 0 && fieldsArr.length === 0 && iconsArr.length === 0) {
-    errors.push("Configuration appears empty — no presets, fields, or icons found");
+  const messagesObj = cfg.messages && typeof cfg.messages === "object" && !Array.isArray(cfg.messages)
+    ? cfg.messages as Record<string, unknown>
+    : {};
+  const hasMessages = Object.keys(messagesObj).length > 0;
+  if (presetsArr.length === 0 && fieldsArr.length === 0 && iconsArr.length === 0 && !hasMessages) {
+    errors.push("Configuration appears empty — no presets, fields, icons, or messages found");
   }
 
   return {

--- a/src/importCategory/validateConfig.ts
+++ b/src/importCategory/validateConfig.ts
@@ -15,9 +15,9 @@ const VALID_FIELD_TYPES = ["text", "number", "selectOne", "selectMultiple"];
  * `package/src/schema/category.js` and `package/src/schema/field.js`.
  *
  * @param config - The parsed configuration object to validate
- * @returns Object with valid flag and array of error messages
+ * @returns Object with isValid flag and array of error messages
  */
-function validateImportedConfig(config: unknown): { valid: boolean; errors: string[] } {
+function validateImportedConfig(config: unknown): { isValid: boolean; errors: string[] } {
   const errors: string[] = [];
 
   // Must be an object
@@ -138,7 +138,7 @@ function validateImportedConfig(config: unknown): { valid: boolean; errors: stri
   }
 
   return {
-    valid: errors.length === 0,
+    isValid: errors.length === 0,
     errors,
   };
 }

--- a/src/importCategory/validateConfig.ts
+++ b/src/importCategory/validateConfig.ts
@@ -84,12 +84,7 @@ function validateImportedConfig(config: unknown): { valid: boolean; errors: stri
 
   // Add summary if errors were capped
   if (errors.length >= MAX_VALIDATION_ERRORS) {
-    const totalItems = (Array.isArray(cfg.presets) ? cfg.presets.length : 0)
-      + (Array.isArray(cfg.fields) ? cfg.fields.length : 0);
-    const remainingItems = totalItems - MAX_VALIDATION_ERRORS;
-    if (remainingItems > 0) {
-      errors.push(`... and up to ${remainingItems} more issues (showing first ${MAX_VALIDATION_ERRORS})`);
-    }
+    errors.push(`... and more issues may exist (showing first ${MAX_VALIDATION_ERRORS})`);
   }
 
   return {

--- a/src/importCategory/validateConfig.ts
+++ b/src/importCategory/validateConfig.ts
@@ -1,0 +1,76 @@
+/**
+ * Validates the structure of imported configuration data before applying to spreadsheet.
+ * Catches malformed .comapeocat files early with clear error messages.
+ *
+ * @param config - The parsed configuration object to validate
+ * @returns Object with valid flag and array of error messages
+ */
+function validateImportedConfig(config: unknown): { valid: boolean; errors: string[] } {
+  const errors: string[] = [];
+
+  // Must be an object
+  if (!config || typeof config !== "object") {
+    return { valid: false, errors: ["Configuration data is not a valid object"] };
+  }
+
+  const cfg = config as Record<string, unknown>;
+
+  // Check required top-level keys
+  if (!Array.isArray(cfg.presets)) {
+    errors.push("Missing or invalid 'presets' array");
+  }
+
+  if (!Array.isArray(cfg.fields)) {
+    errors.push("Missing or invalid 'fields' array");
+  }
+
+  if (!Array.isArray(cfg.icons)) {
+    errors.push("Missing or invalid 'icons' array");
+  }
+
+  if (!cfg.messages || typeof cfg.messages !== "object" || Array.isArray(cfg.messages)) {
+    errors.push("Missing or invalid 'messages' object");
+  }
+
+  // Validate presets structure (if present)
+  if (Array.isArray(cfg.presets)) {
+    for (let i = 0; i < cfg.presets.length; i++) {
+      const preset = cfg.presets[i];
+      if (!preset || typeof preset !== "object") {
+        errors.push(`Preset at index ${i} is not a valid object`);
+        continue;
+      }
+      const p = preset as Record<string, unknown>;
+      if (typeof p.name !== "string" || !p.name.trim()) {
+        errors.push(`Preset at index ${i} missing 'name' property`);
+      }
+    }
+  }
+
+  // Validate fields structure (if present)
+  if (Array.isArray(cfg.fields)) {
+    for (let i = 0; i < cfg.fields.length; i++) {
+      const field = cfg.fields[i];
+      if (!field || typeof field !== "object") {
+        errors.push(`Field at index ${i} is not a valid object`);
+        continue;
+      }
+      const f = field as Record<string, unknown>;
+      if (typeof f.label !== "string" || !f.label.trim()) {
+        errors.push(`Field at index ${i} missing 'label' property`);
+      }
+    }
+  }
+
+  // Validate metadata (optional but should be object if present)
+  if (cfg.metadata !== undefined && cfg.metadata !== null) {
+    if (typeof cfg.metadata !== "object" || Array.isArray(cfg.metadata)) {
+      errors.push("'metadata' should be an object if present");
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}

--- a/src/importCategory/validateConfig.ts
+++ b/src/importCategory/validateConfig.ts
@@ -1,3 +1,6 @@
+/** Maximum number of validation errors to report. Prevents memory issues on corrupt archives. */
+const MAX_VALIDATION_ERRORS = 20;
+
 /**
  * Validates the structure of imported configuration data before applying to spreadsheet.
  * Catches malformed .comapeocat files early with clear error messages.
@@ -34,7 +37,7 @@ function validateImportedConfig(config: unknown): { valid: boolean; errors: stri
 
   // Validate presets structure (if present)
   if (Array.isArray(cfg.presets)) {
-    for (let i = 0; i < cfg.presets.length; i++) {
+    for (let i = 0; i < cfg.presets.length && errors.length < MAX_VALIDATION_ERRORS; i++) {
       const preset = cfg.presets[i];
       if (!preset || typeof preset !== "object") {
         errors.push(`Preset at index ${i} is not a valid object`);
@@ -49,7 +52,7 @@ function validateImportedConfig(config: unknown): { valid: boolean; errors: stri
 
   // Validate fields structure (if present)
   if (Array.isArray(cfg.fields)) {
-    for (let i = 0; i < cfg.fields.length; i++) {
+    for (let i = 0; i < cfg.fields.length && errors.length < MAX_VALIDATION_ERRORS; i++) {
       const field = cfg.fields[i];
       if (!field || typeof field !== "object") {
         errors.push(`Field at index ${i} is not a valid object`);
@@ -77,6 +80,13 @@ function validateImportedConfig(config: unknown): { valid: boolean; errors: stri
   const hasMessages = Object.keys(messagesObj).length > 0;
   if (allArraysValid && cfg.presets.length === 0 && cfg.fields.length === 0 && cfg.icons.length === 0 && !hasMessages) {
     errors.push("Configuration appears empty — no presets, fields, icons, or messages found");
+  }
+
+  // Add summary if errors were capped
+  if (errors.length >= MAX_VALIDATION_ERRORS) {
+    const totalIssues = /* approximate total */ (Array.isArray(cfg.presets) ? cfg.presets.length : 0)
+      + (Array.isArray(cfg.fields) ? cfg.fields.length : 0);
+    errors.push(`... and ${totalIssues - MAX_VALIDATION_ERRORS} more issues (showing first ${MAX_VALIDATION_ERRORS})`);
   }
 
   return {

--- a/src/importCategory/validateConfig.ts
+++ b/src/importCategory/validateConfig.ts
@@ -22,7 +22,7 @@ function validateImportedConfig(config: unknown): { isValid: boolean; errors: st
 
   // Must be an object
   if (!config || typeof config !== "object") {
-    return { valid: false, errors: ["Configuration data is not a valid object"] };
+    return { isValid: false, errors: ["Configuration data is not a valid object"] };
   }
 
   const cfg = config as Record<string, unknown>;
@@ -103,7 +103,7 @@ function validateImportedConfig(config: unknown): { isValid: boolean; errors: st
       }
 
       // type should be a valid enum value
-      if (f.type !== undefined && !VALID_FIELD_TYPES.includes(f.type as string)) {
+      if (f.type !== undefined && !VALID_FIELD_TYPES.includes(f.type as typeof VALID_FIELD_TYPES[number])) {
         if (errors.length < MAX_VALIDATION_ERRORS) {
           errors.push(`Field '${f.id || `index ${i}`}' has unrecognized type '${f.type}' (expected one of: ${VALID_FIELD_TYPES.join(", ")})`);
         }
@@ -126,7 +126,7 @@ function validateImportedConfig(config: unknown): { isValid: boolean; errors: st
     ? (cfg.messages as Record<string, unknown>)
     : {};
   const hasMessages = Object.keys(messagesObj).length > 0;
-  if (allArraysValid && cfg.presets.length === 0 && cfg.fields.length === 0 && cfg.icons.length === 0 && !hasMessages) {
+  if (allArraysValid && (cfg.presets as unknown[]).length === 0 && (cfg.fields as unknown[]).length === 0 && (cfg.icons as unknown[]).length === 0 && !hasMessages) {
     if (errors.length < MAX_VALIDATION_ERRORS) {
       errors.push("Configuration appears empty — no presets, fields, icons, or messages found");
     }

--- a/src/importCategory/validateConfig.ts
+++ b/src/importCategory/validateConfig.ts
@@ -82,9 +82,9 @@ function validateImportedConfig(config: unknown): { valid: boolean; errors: stri
     errors.push("Configuration appears empty — no presets, fields, icons, or messages found");
   }
 
-  // Add summary if errors were capped
+  // Add summary if errors were capped (replace last error to stay within cap)
   if (errors.length >= MAX_VALIDATION_ERRORS) {
-    errors.push(`... and more issues may exist (showing first ${MAX_VALIDATION_ERRORS})`);
+    errors[MAX_VALIDATION_ERRORS - 1] = `... and more issues may exist (showing first ${MAX_VALIDATION_ERRORS - 1})`;
   }
 
   return {

--- a/src/importCategory/validateConfig.ts
+++ b/src/importCategory/validateConfig.ts
@@ -4,8 +4,8 @@ const MAX_VALIDATION_ERRORS = 20;
 /** Valid document types per CoMapeo spec */
 const VALID_DOCUMENT_TYPES = ["observation", "track"];
 
-/** Valid field types per CoMapeo spec */
-const VALID_FIELD_TYPES = ["text", "number", "selectOne", "selectMultiple"];
+// Reuse VALID_FIELD_TYPES from validation.ts (GAS global scope)
+const VALID_IMPORT_FIELD_TYPES: readonly string[] = VALID_FIELD_TYPES;
 
 /**
  * Validates the structure of imported configuration data before applying to spreadsheet.
@@ -103,9 +103,9 @@ function validateImportedConfig(config: unknown): { isValid: boolean; errors: st
       }
 
       // type should be a valid enum value
-      if (f.type !== undefined && !VALID_FIELD_TYPES.includes(f.type as typeof VALID_FIELD_TYPES[number])) {
+      if (f.type !== undefined && !VALID_IMPORT_FIELD_TYPES.includes(f.type as typeof VALID_IMPORT_FIELD_TYPES[number])) {
         if (errors.length < MAX_VALIDATION_ERRORS) {
-          errors.push(`Field '${f.id || `index ${i}`}' has unrecognized type '${f.type}' (expected one of: ${VALID_FIELD_TYPES.join(", ")})`);
+          errors.push(`Field '${f.id || `index ${i}`}' has unrecognized type '${f.type}' (expected one of: ${VALID_IMPORT_FIELD_TYPES.join(", ")})`);
         }
       }
     }

--- a/src/importCategory/validateConfig.ts
+++ b/src/importCategory/validateConfig.ts
@@ -69,15 +69,13 @@ function validateImportedConfig(config: unknown): { valid: boolean; errors: stri
     }
   }
 
-  // Check for completely empty config (no data at all)
-  const presetsArr = Array.isArray(cfg.presets) ? cfg.presets : [];
-  const fieldsArr = Array.isArray(cfg.fields) ? cfg.fields : [];
-  const iconsArr = Array.isArray(cfg.icons) ? cfg.icons : [];
+  // Check for completely empty config (only when all arrays are valid but empty)
+  const allArraysValid = Array.isArray(cfg.presets) && Array.isArray(cfg.fields) && Array.isArray(cfg.icons);
   const messagesObj = cfg.messages && typeof cfg.messages === "object" && !Array.isArray(cfg.messages)
-    ? cfg.messages as Record<string, unknown>
+    ? (cfg.messages as Record<string, unknown>)
     : {};
   const hasMessages = Object.keys(messagesObj).length > 0;
-  if (presetsArr.length === 0 && fieldsArr.length === 0 && iconsArr.length === 0 && !hasMessages) {
+  if (allArraysValid && cfg.presets.length === 0 && cfg.fields.length === 0 && cfg.icons.length === 0 && !hasMessages) {
     errors.push("Configuration appears empty — no presets, fields, icons, or messages found");
   }
 

--- a/src/importCategory/validateConfig.ts
+++ b/src/importCategory/validateConfig.ts
@@ -84,9 +84,12 @@ function validateImportedConfig(config: unknown): { valid: boolean; errors: stri
 
   // Add summary if errors were capped
   if (errors.length >= MAX_VALIDATION_ERRORS) {
-    const totalIssues = /* approximate total */ (Array.isArray(cfg.presets) ? cfg.presets.length : 0)
+    const totalItems = (Array.isArray(cfg.presets) ? cfg.presets.length : 0)
       + (Array.isArray(cfg.fields) ? cfg.fields.length : 0);
-    errors.push(`... and ${totalIssues - MAX_VALIDATION_ERRORS} more issues (showing first ${MAX_VALIDATION_ERRORS})`);
+    const remainingItems = totalItems - MAX_VALIDATION_ERRORS;
+    if (remainingItems > 0) {
+      errors.push(`... and up to ${remainingItems} more issues (showing first ${MAX_VALIDATION_ERRORS})`);
+    }
   }
 
   return {

--- a/src/importCategory/validateConfig.ts
+++ b/src/importCategory/validateConfig.ts
@@ -68,7 +68,9 @@ function validateImportedConfig(config: unknown): { valid: boolean; errors: stri
   // Validate metadata (optional but should be object if present)
   if (cfg.metadata !== undefined && cfg.metadata !== null) {
     if (typeof cfg.metadata !== "object" || Array.isArray(cfg.metadata)) {
-      errors.push("'metadata' should be an object if present");
+      if (errors.length < MAX_VALIDATION_ERRORS) {
+        errors.push("'metadata' should be an object if present");
+      }
     }
   }
 
@@ -79,7 +81,9 @@ function validateImportedConfig(config: unknown): { valid: boolean; errors: stri
     : {};
   const hasMessages = Object.keys(messagesObj).length > 0;
   if (allArraysValid && cfg.presets.length === 0 && cfg.fields.length === 0 && cfg.icons.length === 0 && !hasMessages) {
-    errors.push("Configuration appears empty — no presets, fields, icons, or messages found");
+    if (errors.length < MAX_VALIDATION_ERRORS) {
+      errors.push("Configuration appears empty — no presets, fields, icons, or messages found");
+    }
   }
 
   // Add summary if errors were capped (replace last error to stay within cap)

--- a/src/importDropzone.ts
+++ b/src/importDropzone.ts
@@ -11,6 +11,8 @@ declare function extractConfigurationData(
   extractedFiles: GoogleAppsScript.Base.Blob[],
   tempFolder: GoogleAppsScript.Drive.Folder,
 ): ImportedConfig;
+// NormalizedConfig is declared in formatDetection.ts (GAS global scope)
+declare type NormalizedConfig = import("./formatDetection").NormalizedConfig;
 declare function normalizeConfig(jsonData: unknown): NormalizedConfig;
 declare function applyConfigurationToSpreadsheet(config: ImportedConfig): void;
 

--- a/src/importDropzone.ts
+++ b/src/importDropzone.ts
@@ -823,6 +823,14 @@ function importConfigurationFile(
         `- Fields: ${configData.fields ? configData.fields.length : 0}`,
       );
       console.log(`- Icons: ${configData.icons ? configData.icons.length : 0}`);
+
+      // Validate the imported config structure
+      const validation = validateImportedConfig(configData);
+      if (!validation.valid) {
+        console.warn(`Config validation warnings: ${validation.errors.join("; ")}`);
+      } else {
+        console.log("Config validation passed");
+      }
     } catch (error) {
       console.error("Error extracting configuration data:", error);
       return {

--- a/src/importDropzone.ts
+++ b/src/importDropzone.ts
@@ -698,6 +698,13 @@ function processMapeoSettingsFile(
 
     // Return success
     console.log("Import completed successfully");
+
+    // Collect all warnings: extraction + config validation
+    const allWarnings = [
+      ...(extractionResult.validationWarnings || []),
+      ...(configData._validationWarnings || []),
+    ];
+
     return {
       success: true,
       message: "Mapeo settings file imported successfully",
@@ -706,6 +713,7 @@ function processMapeoSettingsFile(
         fields: configData.fields ? configData.fields.length : 0,
         icons: configData.icons ? configData.icons.length : 0,
       },
+      warnings: allWarnings,
     };
   } catch (error) {
     console.error("Error processing Mapeo settings file:", error);

--- a/src/importDropzone.ts
+++ b/src/importDropzone.ts
@@ -824,13 +824,8 @@ function importConfigurationFile(
       );
       console.log(`- Icons: ${configData.icons ? configData.icons.length : 0}`);
 
-      // Validate the imported config structure
-      const validation = validateImportedConfig(configData);
-      if (!validation.valid) {
-        console.warn(`Config validation warnings: ${validation.errors.join("; ")}`);
-      } else {
-        console.log("Config validation passed");
-      }
+      // Validation already performed inside parseExtractedFiles()
+      // which logs warnings for structural issues
     } catch (error) {
       console.error("Error extracting configuration data:", error);
       return {

--- a/src/importDropzone.ts
+++ b/src/importDropzone.ts
@@ -859,6 +859,13 @@ function importConfigurationFile(
     // Return success
     console.log("Import completed successfully");
     const fileType = fileName.endsWith(".comapeocat") ? "CoMapeo" : "Mapeo";
+
+    // Collect all warnings: extraction + config validation
+    const allWarnings = [
+      ...(extractionResult.validationWarnings || []),
+      ...((configData as Record<string, unknown>)._validationWarnings || []),
+    ];
+
     return {
       success: true,
       message: `${fileType} category file imported successfully`,
@@ -868,7 +875,7 @@ function importConfigurationFile(
         icons: configData.icons ? configData.icons.length : 0,
         languages: Object.keys(configData.messages).length,
       },
-      warnings: extractionResult.validationWarnings || [],
+      warnings: allWarnings,
     };
   } catch (error) {
     console.error("Error importing configuration file:", error);

--- a/src/importDropzone.ts
+++ b/src/importDropzone.ts
@@ -6,13 +6,13 @@ declare function createOrClearSheet(
 declare function processImportedCategoryFile(
   fileName: string,
   base64Data: string,
-): { success: boolean; message: string; details?: any; warnings?: string[] };
+): ImportResult;
 declare function extractConfigurationData(
   extractedFiles: GoogleAppsScript.Base.Blob[],
   tempFolder: GoogleAppsScript.Drive.Folder,
-): any;
-declare function normalizeConfig(jsonData: any): any;
-declare function applyConfigurationToSpreadsheet(config: any): void;
+): ImportedConfig;
+declare function normalizeConfig(jsonData: unknown): ImportedConfig;
+declare function applyConfigurationToSpreadsheet(config: ImportedConfig): void;
 
 /**
  * Interface for dropzone configuration options
@@ -600,7 +600,7 @@ function createDropzoneHtml(): string {
 function processMapeoSettingsFile(
   fileName: string,
   base64Data: string,
-): { success: boolean; message: string; details?: any } {
+): ImportResult {
   try {
     console.log(`Starting import of Mapeo settings file: ${fileName}`);
 
@@ -622,14 +622,7 @@ function processMapeoSettingsFile(
 
     // Extract the file - using the direct approach from testImportCategory.ts
     console.log("Extracting file...");
-    let extractionResult: {
-      success: boolean;
-      message: string;
-      files?: GoogleAppsScript.Base.Blob[];
-      tempFolder?: GoogleAppsScript.Drive.Folder;
-      validationErrors?: string[];
-      validationWarnings?: string[];
-    };
+    let extractionResult: ExtractionResult;
 
     try {
       // Use the simple call without progress handler
@@ -656,13 +649,7 @@ function processMapeoSettingsFile(
 
     // Extract configuration data
     console.log("Extracting configuration data...");
-    let configData: {
-      metadata: any;
-      presets: any[];
-      fields: any[];
-      icons: any[];
-      messages: Record<string, any>;
-    };
+    let configData: ImportedConfig;
 
     try {
       // Use the simple call without progress handler
@@ -738,7 +725,7 @@ function processMapeoSettingsFile(
 function handleFileImport(
   fileName: string,
   base64Data: string,
-): { success: boolean; message: string; details?: any } {
+): ImportResult {
   try {
     // Validate file extension
     const fileExtension = fileName.toString().split(".").pop()?.toLowerCase();
@@ -770,7 +757,7 @@ function handleFileImport(
 function importConfigurationFile(
   fileName: string,
   base64Data: string,
-): { success: boolean; message: string; details?: any; warnings?: string[] } {
+): ImportResult {
   try {
     console.log(`Starting import of file: ${fileName}`);
 
@@ -792,14 +779,7 @@ function importConfigurationFile(
 
     // Extract the file - using the direct approach from testImportCategory.ts
     console.log("Extracting file...");
-    let extractionResult: {
-      success: boolean;
-      message: string;
-      files?: GoogleAppsScript.Base.Blob[];
-      tempFolder?: GoogleAppsScript.Drive.Folder;
-      validationErrors?: string[];
-      validationWarnings?: string[];
-    };
+    let extractionResult: ExtractionResult;
 
     try {
       // Use the simple call without progress handler
@@ -826,13 +806,7 @@ function importConfigurationFile(
 
     // Extract configuration data
     console.log("Extracting configuration data...");
-    let configData: {
-      metadata: any;
-      presets: any[];
-      fields: any[];
-      icons: any[];
-      messages: Record<string, any>;
-    };
+    let configData: ImportedConfig;
 
     try {
       // Use the simple call without progress handler

--- a/src/importDropzone.ts
+++ b/src/importDropzone.ts
@@ -863,7 +863,7 @@ function importConfigurationFile(
     // Collect all warnings: extraction + config validation
     const allWarnings = [
       ...(extractionResult.validationWarnings || []),
-      ...((configData as Record<string, unknown>)._validationWarnings || []),
+      ...(configData._validationWarnings || []),
     ];
 
     return {

--- a/src/importDropzone.ts
+++ b/src/importDropzone.ts
@@ -11,7 +11,7 @@ declare function extractConfigurationData(
   extractedFiles: GoogleAppsScript.Base.Blob[],
   tempFolder: GoogleAppsScript.Drive.Folder,
 ): ImportedConfig;
-declare function normalizeConfig(jsonData: unknown): ImportedConfig;
+declare function normalizeConfig(jsonData: unknown): NormalizedConfig;
 declare function applyConfigurationToSpreadsheet(config: ImportedConfig): void;
 
 /**

--- a/src/test/testBuildAndImport.ts
+++ b/src/test/testBuildAndImport.ts
@@ -2245,7 +2245,7 @@ function testValidateImportedConfigValid(): boolean {
   try {
     const config = createValidImportedConfig();
     const result = validateImportedConfig(config);
-    if (!result.valid) {
+    if (!result.isValid) {
       console.error("FAIL: Valid config should pass, got errors:", result.errors.join("; "));
       return false;
     }
@@ -2270,7 +2270,7 @@ function testValidateImportedConfigMissingAppliesTo(): boolean {
     delete preset.appliesTo;
 
     const result = validateImportedConfig(config);
-    if (result.valid) {
+    if (result.isValid) {
       console.error("FAIL: Config missing appliesTo should fail validation");
       return false;
     }
@@ -2295,7 +2295,7 @@ function testValidateImportedConfigMissingTags(): boolean {
     delete preset.tags;
 
     const result = validateImportedConfig(config);
-    if (result.valid) {
+    if (result.isValid) {
       console.error("FAIL: Config missing tags should fail validation");
       return false;
     }
@@ -2319,7 +2319,7 @@ function testValidateImportedConfigEmptyTags(): boolean {
     config.presets[0].tags = {};
 
     const result = validateImportedConfig(config);
-    if (result.valid) {
+    if (result.isValid) {
       console.error("FAIL: Config with empty tags should fail");
       return false;
     }
@@ -2343,7 +2343,7 @@ function testValidateImportedConfigInvalidAppliesToValue(): boolean {
     config.presets[0].appliesTo = ["invalid-type" as any];
 
     const result = validateImportedConfig(config);
-    if (result.valid) {
+    if (result.isValid) {
       console.error("FAIL: Config with invalid appliesTo should fail");
       return false;
     }
@@ -2368,7 +2368,7 @@ function testValidateImportedConfigMissingFieldTagKey(): boolean {
     delete field.tagKey;
 
     const result = validateImportedConfig(config);
-    if (result.valid) {
+    if (result.isValid) {
       console.error("FAIL: Config missing field tagKey should fail");
       return false;
     }
@@ -2392,7 +2392,7 @@ function testValidateImportedConfigInvalidFieldType(): boolean {
     config.fields[0].type = "select2" as any;
 
     const result = validateImportedConfig(config);
-    if (result.valid) {
+    if (result.isValid) {
       console.error("FAIL: Config with invalid field type should fail");
       return false;
     }
@@ -2418,7 +2418,7 @@ function testValidateImportedConfigEmptyConfig(): boolean {
       icons: [],
       messages: {},
     });
-    if (result.valid) {
+    if (result.isValid) {
       console.error("FAIL: Empty config should fail");
       return false;
     }
@@ -2439,7 +2439,7 @@ function testValidateImportedConfigNotObject(): boolean {
   console.log("=== Test: Validate Imported Config - Non-object input ===");
   try {
     const result = validateImportedConfig(null);
-    if (result.valid) {
+    if (result.isValid) {
       console.error("FAIL: null should fail");
       return false;
     }
@@ -2450,7 +2450,7 @@ function testValidateImportedConfigNotObject(): boolean {
     console.log("PASS: null correctly rejected");
 
     const result2 = validateImportedConfig("string");
-    if (result2.valid) {
+    if (result2.isValid) {
       console.error("FAIL: string should fail");
       return false;
     }
@@ -2470,7 +2470,7 @@ function testValidateImportedConfigAllFieldTypes(): boolean {
       const config = createValidImportedConfig();
       config.fields[0].type = type as FieldType;
       const result = validateImportedConfig(config);
-      if (!result.valid) {
+      if (!result.isValid) {
         console.error(`FAIL: Field type '${type}' should be valid, got:`, result.errors.join("; "));
         return false;
       }
@@ -2497,7 +2497,7 @@ function testValidateImportedConfigTagValueTypes(): boolean {
       const config = createValidImportedConfig();
       config.presets[0].tags = { "test-key": value };
       const result = validateImportedConfig(config);
-      if (!result.valid) {
+      if (!result.isValid) {
         console.error(`FAIL: Tag value type '${desc}' should be valid, got:`, result.errors.join("; "));
         return false;
       }

--- a/src/test/testBuildAndImport.ts
+++ b/src/test/testBuildAndImport.ts
@@ -2175,6 +2175,342 @@ function testOptionTranslationsWithLocalizedSeparators(): boolean {
 }
 
 // =============================================================================
+// Import Config Validation Tests
+// =============================================================================
+
+/**
+ * Creates a minimal valid ImportedConfig for testing.
+ * Matches the canonical CoMapeo category schema from package/src/schema/.
+ */
+function createValidImportedConfig(): ImportedConfig {
+  return {
+    metadata: { name: "Test Config", version: "1.0.0" },
+    presets: [
+      {
+        id: "animal",
+        name: "Animal",
+        appliesTo: ["observation"],
+        tags: { type: "animal" },
+        icon: "animal",
+        color: "#9E2C54",
+        fields: ["animal-type"],
+        terms: [],
+      },
+      {
+        id: "threat",
+        name: "Threat",
+        appliesTo: ["observation", "track"],
+        tags: { type: "impact", impact: "threat" },
+        icon: "threat",
+        color: "#D63E03",
+        fields: [],
+        terms: ["danger", "illegal"],
+      },
+    ],
+    fields: [
+      {
+        id: "animal-type",
+        tagKey: "animal-type",
+        label: "Animal type",
+        type: "text",
+        helperText: "What kind of animal?",
+      },
+      {
+        id: "building-type",
+        tagKey: "building-type",
+        label: "Building type",
+        type: "selectOne",
+        options: [
+          { label: "School", value: "School" },
+          { label: "Hospital", value: "Hospital" },
+        ],
+      },
+    ],
+    icons: [
+      { name: "animal", svg: "https://example.com/animal.svg", id: "animal" },
+    ],
+    messages: {
+      en: {
+        presets: {
+          presets: { animal: { name: "Animal" } },
+          fields: { "animal-type": { label: "Animal type" } },
+        },
+      },
+    },
+  };
+}
+
+function testValidateImportedConfigValid(): boolean {
+  console.log("=== Test: Validate Imported Config - Valid ===");
+  try {
+    const config = createValidImportedConfig();
+    const result = validateImportedConfig(config);
+    if (!result.valid) {
+      console.error("FAIL: Valid config should pass, got errors:", result.errors.join("; "));
+      return false;
+    }
+    if (result.errors.length !== 0) {
+      console.error("FAIL: Valid config should have 0 errors, got:", result.errors.length);
+      return false;
+    }
+    console.log("PASS: Valid config passes validation");
+    return true;
+  } catch (error) {
+    console.error("FAIL: Exception thrown -", error instanceof Error ? error.message : String(error));
+    return false;
+  }
+}
+
+function testValidateImportedConfigMissingAppliesTo(): boolean {
+  console.log("=== Test: Validate Imported Config - Missing appliesTo ===");
+  try {
+    const config = createValidImportedConfig();
+    // Remove appliesTo from first preset
+    const preset = config.presets[0] as Record<string, unknown>;
+    delete preset.appliesTo;
+
+    const result = validateImportedConfig(config);
+    if (result.valid) {
+      console.error("FAIL: Config missing appliesTo should fail validation");
+      return false;
+    }
+    const hasAppliesToError = result.errors.some((e) => e.includes("appliesTo"));
+    if (!hasAppliesToError) {
+      console.error("FAIL: Expected appliesTo error, got:", result.errors.join("; "));
+      return false;
+    }
+    console.log("PASS: Missing appliesTo correctly detected:", result.errors[0]);
+    return true;
+  } catch (error) {
+    console.error("FAIL: Exception thrown -", error instanceof Error ? error.message : String(error));
+    return false;
+  }
+}
+
+function testValidateImportedConfigMissingTags(): boolean {
+  console.log("=== Test: Validate Imported Config - Missing tags ===");
+  try {
+    const config = createValidImportedConfig();
+    const preset = config.presets[0] as Record<string, unknown>;
+    delete preset.tags;
+
+    const result = validateImportedConfig(config);
+    if (result.valid) {
+      console.error("FAIL: Config missing tags should fail validation");
+      return false;
+    }
+    const hasTagsError = result.errors.some((e) => e.includes("tags"));
+    if (!hasTagsError) {
+      console.error("FAIL: Expected tags error, got:", result.errors.join("; "));
+      return false;
+    }
+    console.log("PASS: Missing tags correctly detected:", result.errors[0]);
+    return true;
+  } catch (error) {
+    console.error("FAIL: Exception thrown -", error instanceof Error ? error.message : String(error));
+    return false;
+  }
+}
+
+function testValidateImportedConfigEmptyTags(): boolean {
+  console.log("=== Test: Validate Imported Config - Empty tags object ===");
+  try {
+    const config = createValidImportedConfig();
+    config.presets[0].tags = {};
+
+    const result = validateImportedConfig(config);
+    if (result.valid) {
+      console.error("FAIL: Config with empty tags should fail");
+      return false;
+    }
+    const hasTagsError = result.errors.some((e) => e.includes("tags"));
+    if (!hasTagsError) {
+      console.error("FAIL: Expected tags error, got:", result.errors.join("; "));
+      return false;
+    }
+    console.log("PASS: Empty tags correctly detected");
+    return true;
+  } catch (error) {
+    console.error("FAIL: Exception thrown -", error instanceof Error ? error.message : String(error));
+    return false;
+  }
+}
+
+function testValidateImportedConfigInvalidAppliesToValue(): boolean {
+  console.log("=== Test: Validate Imported Config - Invalid appliesTo value ===");
+  try {
+    const config = createValidImportedConfig();
+    config.presets[0].appliesTo = ["invalid-type" as any];
+
+    const result = validateImportedConfig(config);
+    if (result.valid) {
+      console.error("FAIL: Config with invalid appliesTo should fail");
+      return false;
+    }
+    const hasError = result.errors.some((e) => e.includes("unrecognized appliesTo"));
+    if (!hasError) {
+      console.error("FAIL: Expected unrecognized appliesTo error, got:", result.errors.join("; "));
+      return false;
+    }
+    console.log("PASS: Invalid appliesTo value correctly detected");
+    return true;
+  } catch (error) {
+    console.error("FAIL: Exception thrown -", error instanceof Error ? error.message : String(error));
+    return false;
+  }
+}
+
+function testValidateImportedConfigMissingFieldTagKey(): boolean {
+  console.log("=== Test: Validate Imported Config - Missing field tagKey ===");
+  try {
+    const config = createValidImportedConfig();
+    const field = config.fields[0] as Record<string, unknown>;
+    delete field.tagKey;
+
+    const result = validateImportedConfig(config);
+    if (result.valid) {
+      console.error("FAIL: Config missing field tagKey should fail");
+      return false;
+    }
+    const hasError = result.errors.some((e) => e.includes("tagKey"));
+    if (!hasError) {
+      console.error("FAIL: Expected tagKey error, got:", result.errors.join("; "));
+      return false;
+    }
+    console.log("PASS: Missing field tagKey correctly detected");
+    return true;
+  } catch (error) {
+    console.error("FAIL: Exception thrown -", error instanceof Error ? error.message : String(error));
+    return false;
+  }
+}
+
+function testValidateImportedConfigInvalidFieldType(): boolean {
+  console.log("=== Test: Validate Imported Config - Invalid field type ===");
+  try {
+    const config = createValidImportedConfig();
+    config.fields[0].type = "select2" as any;
+
+    const result = validateImportedConfig(config);
+    if (result.valid) {
+      console.error("FAIL: Config with invalid field type should fail");
+      return false;
+    }
+    const hasError = result.errors.some((e) => e.includes("unrecognized type"));
+    if (!hasError) {
+      console.error("FAIL: Expected unrecognized type error, got:", result.errors.join("; "));
+      return false;
+    }
+    console.log("PASS: Invalid field type correctly detected");
+    return true;
+  } catch (error) {
+    console.error("FAIL: Exception thrown -", error instanceof Error ? error.message : String(error));
+    return false;
+  }
+}
+
+function testValidateImportedConfigEmptyConfig(): boolean {
+  console.log("=== Test: Validate Imported Config - Empty config ===");
+  try {
+    const result = validateImportedConfig({
+      presets: [],
+      fields: [],
+      icons: [],
+      messages: {},
+    });
+    if (result.valid) {
+      console.error("FAIL: Empty config should fail");
+      return false;
+    }
+    const hasError = result.errors.some((e) => e.includes("empty"));
+    if (!hasError) {
+      console.error("FAIL: Expected empty config error, got:", result.errors.join("; "));
+      return false;
+    }
+    console.log("PASS: Empty config correctly detected");
+    return true;
+  } catch (error) {
+    console.error("FAIL: Exception thrown -", error instanceof Error ? error.message : String(error));
+    return false;
+  }
+}
+
+function testValidateImportedConfigNotObject(): boolean {
+  console.log("=== Test: Validate Imported Config - Non-object input ===");
+  try {
+    const result = validateImportedConfig(null);
+    if (result.valid) {
+      console.error("FAIL: null should fail");
+      return false;
+    }
+    if (result.errors.length !== 1) {
+      console.error("FAIL: Expected 1 error, got:", result.errors.length);
+      return false;
+    }
+    console.log("PASS: null correctly rejected");
+
+    const result2 = validateImportedConfig("string");
+    if (result2.valid) {
+      console.error("FAIL: string should fail");
+      return false;
+    }
+    console.log("PASS: Non-object inputs correctly rejected");
+    return true;
+  } catch (error) {
+    console.error("FAIL: Exception thrown -", error instanceof Error ? error.message : String(error));
+    return false;
+  }
+}
+
+function testValidateImportedConfigAllFieldTypes(): boolean {
+  console.log("=== Test: Validate Imported Config - All valid field types ===");
+  try {
+    const validTypes = ["text", "number", "selectOne", "selectMultiple"];
+    for (const type of validTypes) {
+      const config = createValidImportedConfig();
+      config.fields[0].type = type as FieldType;
+      const result = validateImportedConfig(config);
+      if (!result.valid) {
+        console.error(`FAIL: Field type '${type}' should be valid, got:`, result.errors.join("; "));
+        return false;
+      }
+    }
+    console.log("PASS: All valid field types accepted:", validTypes.join(", "));
+    return true;
+  } catch (error) {
+    console.error("FAIL: Exception thrown -", error instanceof Error ? error.message : String(error));
+    return false;
+  }
+}
+
+function testValidateImportedConfigTagValueTypes(): boolean {
+  console.log("=== Test: Validate Imported Config - Tag value types ===");
+  try {
+    // Tags should accept boolean, number, string, null per spec
+    const tagValues: Array<{ value: TagValue; desc: string }> = [
+      { value: "string", desc: "string" },
+      { value: true, desc: "boolean" },
+      { value: 42, desc: "number" },
+      { value: null, desc: "null" },
+    ];
+    for (const { value, desc } of tagValues) {
+      const config = createValidImportedConfig();
+      config.presets[0].tags = { "test-key": value };
+      const result = validateImportedConfig(config);
+      if (!result.valid) {
+        console.error(`FAIL: Tag value type '${desc}' should be valid, got:`, result.errors.join("; "));
+        return false;
+      }
+    }
+    console.log("PASS: All tag value types accepted (string, boolean, number, null)");
+    return true;
+  } catch (error) {
+    console.error("FAIL: Exception thrown -", error instanceof Error ? error.message : String(error));
+    return false;
+  }
+}
+
+// =============================================================================
 // Test Runner
 // =============================================================================
 
@@ -2232,7 +2568,20 @@ function runBuildAndImportTests(): void {
 
     // Category and API tests
     { name: "Category Selection", fn: testCategorySelection },
-    { name: "API Error Parsing", fn: testApiErrorParsing }
+    { name: "API Error Parsing", fn: testApiErrorParsing },
+
+    // Import config validation tests (spec conformance)
+    { name: "Validate Config - Valid", fn: testValidateImportedConfigValid },
+    { name: "Validate Config - Missing appliesTo", fn: testValidateImportedConfigMissingAppliesTo },
+    { name: "Validate Config - Missing tags", fn: testValidateImportedConfigMissingTags },
+    { name: "Validate Config - Empty tags", fn: testValidateImportedConfigEmptyTags },
+    { name: "Validate Config - Invalid appliesTo value", fn: testValidateImportedConfigInvalidAppliesToValue },
+    { name: "Validate Config - Missing field tagKey", fn: testValidateImportedConfigMissingFieldTagKey },
+    { name: "Validate Config - Invalid field type", fn: testValidateImportedConfigInvalidFieldType },
+    { name: "Validate Config - Empty config", fn: testValidateImportedConfigEmptyConfig },
+    { name: "Validate Config - Non-object input", fn: testValidateImportedConfigNotObject },
+    { name: "Validate Config - All valid field types", fn: testValidateImportedConfigAllFieldTypes },
+    { name: "Validate Config - Tag value types", fn: testValidateImportedConfigTagValueTypes }
   ];
 
   let passed = 0;

--- a/src/types.ts
+++ b/src/types.ts
@@ -320,9 +320,6 @@ type TagValue = boolean | number | string | null;
 /** Valid document types for appliesTo per CoMapeo spec */
 type DocumentType = "observation" | "track";
 
-/** Valid field types per CoMapeo spec */
-type FieldType = "text" | "number" | "selectOne" | "selectMultiple";
-
 /** Imported preset from a .comapeocat archive */
 interface ImportedPreset {
   id: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -309,3 +309,118 @@ interface CategoryRow extends Array<string | number | boolean> {
   3?: string; // Color (optional)
   4?: string; // Geometry (optional)
 }
+
+// ============================================
+// Import Pipeline Types
+// ============================================
+
+/** Imported preset from a .comapeocat archive */
+interface ImportedPreset {
+  id: string;
+  name: string;
+  icon: string;
+  color: string;
+  fields: string[];
+  geometry?: string[];
+  tags?: Record<string, string>;
+  terms?: string[];
+  sort?: number;
+}
+
+/** Imported field from a .comapeocat archive */
+interface ImportedField {
+  id: string;
+  tagKey: string;
+  label: string;
+  type: string;
+  helperText?: string;
+  placeholder?: string;
+  options?: Array<{ label: string; value: string }>;
+  universal?: boolean;
+}
+
+/** Imported icon extracted from archive */
+interface ImportedIcon {
+  name: string;
+  svg: string;
+  id: string;
+}
+
+/** Imported metadata from metadata.json */
+interface ImportedMetadata {
+  name: string;
+  version?: string;
+  description?: string;
+  dataset_id?: string;
+  [key: string]: unknown;
+}
+
+/** Translation option with label/value */
+interface TranslationOption {
+  label: string;
+  value: string;
+}
+
+/** Translation field data */
+interface TranslationField {
+  name?: string;
+  label?: string;
+  description?: string;
+  helperText?: string;
+  placeholder?: string;
+  options?: Record<string, TranslationOption>;
+  [key: string]: unknown;
+}
+
+/** Translation preset/category data */
+interface TranslationPreset {
+  name?: string;
+  label?: string;
+  description?: string;
+  options?: Record<string, TranslationOption>;
+  [key: string]: unknown;
+}
+
+/** Translation data for a single locale */
+interface TranslationLocaleData {
+  presets: {
+    presets: Record<string, TranslationPreset>;
+    fields: Record<string, TranslationField>;
+  };
+}
+
+/** Full configuration data extracted from an archive */
+interface ImportedConfig {
+  metadata: ImportedMetadata | null;
+  presets: ImportedPreset[];
+  fields: ImportedField[];
+  icons: ImportedIcon[];
+  messages: Record<string, TranslationLocaleData>;
+  iconsSvgFile?: GoogleAppsScript.Base.Blob;
+  iconsPngFile?: GoogleAppsScript.Base.Blob;
+  iconsJsonFile?: GoogleAppsScript.Base.Blob;
+}
+
+/** Result of file extraction */
+interface ExtractionResult {
+  success: boolean;
+  message: string;
+  files?: GoogleAppsScript.Base.Blob[];
+  tempFolder?: GoogleAppsScript.Drive.Folder;
+  validationErrors?: string[];
+  validationWarnings?: string[];
+}
+
+/** Result of import operation */
+interface ImportResult {
+  success: boolean;
+  message: string;
+  details?: {
+    presets?: number;
+    fields?: number;
+    icons?: number;
+    languages?: number | string[] | Record<string, unknown>;
+    processingTime?: number;
+  };
+  warnings?: string[];
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -314,17 +314,40 @@ interface CategoryRow extends Array<string | number | boolean> {
 // Import Pipeline Types
 // ============================================
 
+/** Tag value type per CoMapeo spec — allows boolean, number, string, or null */
+type TagValue = boolean | number | string | null;
+
+/** Valid document types for appliesTo per CoMapeo spec */
+type DocumentType = "observation" | "track";
+
+/** Valid field types per CoMapeo spec */
+type FieldType = "text" | "number" | "selectOne" | "selectMultiple";
+
 /** Imported preset from a .comapeocat archive */
 interface ImportedPreset {
   id: string;
+  /** Required: display name for the category */
   name: string;
-  icon: string;
-  color: string;
+  /** Required: which document types this category applies to */
+  appliesTo: DocumentType[];
+  /** Required: tags used to match this category to map entities */
+  tags: Record<string, TagValue>;
+  /** Optional: icon identifier */
+  icon?: string;
+  /** Optional: color in hex format */
+  color?: string;
+  /** Optional: field IDs to show for this category */
   fields: string[];
-  geometry?: string[];
-  tags?: Record<string, string>;
+  /** Optional: tags added when changing to this category */
+  addTags?: Record<string, TagValue>;
+  /** Optional: tags removed when changing away from this category */
+  removeTags?: Record<string, TagValue>;
+  /** Optional: synonyms for search */
   terms?: string[];
+  /** @deprecated Use categorySelection.json instead */
   sort?: number;
+  /** @deprecated Use appliesTo instead */
+  geometry?: string[];
 }
 
 /** Imported field from a .comapeocat archive */
@@ -332,10 +355,10 @@ interface ImportedField {
   id: string;
   tagKey: string;
   label: string;
-  type: string;
+  type: FieldType;
   helperText?: string;
   placeholder?: string;
-  options?: Array<{ label: string; value: string }>;
+  options?: Array<{ label: string; value: string | boolean | number | null }>;
   universal?: boolean;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -399,6 +399,8 @@ interface ImportedConfig {
   iconsSvgFile?: GoogleAppsScript.Base.Blob;
   iconsPngFile?: GoogleAppsScript.Base.Blob;
   iconsJsonFile?: GoogleAppsScript.Base.Blob;
+  /** Validation warnings attached by parseExtractedFiles. Not part of the archive format. */
+  _validationWarnings?: string[];
 }
 
 /** Result of file extraction */


### PR DESCRIPTION
## Problem

`parseFiles.ts` parsed JSON from `.comapeocat` archives but did not validate the structure before applying to the spreadsheet. A malformed archive could write garbage data to sheets, with confusing errors deep in the apply pipeline.

## Changes

### New file: `src/importCategory/validateConfig.ts`

`validateImportedConfig(config)` checks:
- Required top-level keys: `presets` (array), `fields` (array), `icons` (array), `messages` (object)
- Each preset has a `name` property
- Each field has a `label` property
- `metadata` is an object if present

Returns `{ valid: boolean; errors: string[] }`.

### Integration points

1. **`parseExtractedFiles()`** — validates before returning `configData`. Non-blocking (warns only).
2. **`importConfigurationFile()`** — validates after extraction. Non-blocking (logs warnings).

### Design decision

Validation is **non-blocking** — it warns on structural issues but allows the import to proceed. This is because:
- Some fields may be optional in certain archive versions
- Better to import partial data than fail entirely
- Users get clear warnings about what might be wrong

Closes #41

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds structural validation for `.comapeocat` archive imports via `validateImportedConfig()`, preventing malformed archives from silently writing garbage data to the spreadsheet. It also formalizes TypeScript types for the entire import pipeline, replacing `any` with `ImportedPreset`, `ImportedField`, `ImportedConfig`, `ExtractionResult`, and `ImportResult`.

- **`validateConfig.ts`** checks required top-level keys (`presets`, `fields`, `icons`, `messages`), validates each preset for `name`, `appliesTo` (against the CoMapeo spec values), and non-empty `tags`, and checks each field for `label`, `tagKey`, and a known `type` enum — errors are capped at 20 and attached as `_validationWarnings` on `ImportedConfig`.
- Validation warnings are now correctly collected and propagated in all three import functions (`processImportedCategoryFile`, `processImportedCategoryFileWithProgress`, `processMapeoSettingsFile`), fixing the previously identified gap where Mapeo-path warnings were silently dropped.
- A comprehensive test suite (`testBuildAndImport.ts`) covers 11 new validator scenarios including valid configs, missing required fields, invalid enum values, empty configs, and all valid field types.

<h3>Confidence Score: 5/5</h3>

Safe to merge — validation is non-blocking, all three import paths correctly propagate warnings, and the type changes are additive with no behavioral regressions.

The validation layer is well-scoped: it runs after parsing, attaches errors as optional metadata, and lets the import proceed so partial archives still work. Warning propagation, which was previously broken on the Mapeo settings path, is now correctly wired in all three import functions. The new TypeScript interfaces tighten the existing any-heavy code without changing runtime behavior. The 11-test suite covers the key validator paths including edge cases.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/importCategory/validateConfig.ts | New file implementing validateImportedConfig(); correctly validates top-level keys, per-preset appliesTo/tags/name, per-field label/tagKey/type, optional metadata, and empty-config detection. Error cap logic and post-loop guards are correct. |
| src/types.ts | Adds ImportedPreset, ImportedField, ImportedIcon, ImportedMetadata, TranslationLocaleData, ImportedConfig, ExtractionResult, and ImportResult interfaces, replacing inline any types across the import pipeline. |
| src/importCategory/parseFiles.ts | Validates config after parsing and attaches _validationWarnings; adds new preset fields (appliesTo, tags, addTags, etc.); replaces any with proper types throughout. |
| src/importDropzone.ts | All three import functions now collect _validationWarnings alongside extraction warnings; return type unified to ImportResult; inline anonymous types replaced with named interfaces. |
| src/importCategory/importProgressHandler.ts | Warning collection pattern mirrored from importCategory.ts; allWarnings correctly merges extraction and validation warnings before the success return. |
| src/importCategory/extractPngIcons.ts | Minimal change: presets parameter tightened from any[] to ImportedPreset[]. No behavioral change. |
| src/importCategory.ts | Adds allWarnings aggregation that merges extraction and config-validation warnings; return type unified to ImportResult. |
| src/test/testBuildAndImport.ts | Adds 11 focused unit tests for validateImportedConfig covering valid configs, missing properties, invalid enum values, empty configs, all field types, and tag value types. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Caller (importDropzone)
    participant E as extractArchive()
    participant P as parseExtractedFiles()
    participant V as validateImportedConfig()
    participant A as applyConfigurationToSpreadsheet()

    C->>E: base64Data
    E-->>C: "ExtractionResult {files, validationWarnings?}"
    C->>P: files, tempFolder
    P->>P: Parse JSON blobs into ImportedConfig
    P->>V: ImportedConfig
    V-->>P: "{isValid, errors[]}"
    alt validation failed
        P->>P: "configData._validationWarnings = errors"
    end
    P-->>C: ImportedConfig (with optional _validationWarnings)
    C->>C: "allWarnings = extractionResult.validationWarnings + configData._validationWarnings"
    C->>A: ImportedConfig
    A-->>C: void
    C-->>C: "ImportResult {success, warnings: allWarnings}"
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/importDropzone.ts`, line 700-709 ([link](https://github.com/digidem/comapeo-category-spreadsheet-plugin/blob/5c01a09ce2684a7a28ee1070523b8c5bbdafdefa/src/importDropzone.ts#L700-L709)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Validation warnings silently dropped in Mapeo import path**

   `importConfigurationFile` was updated to collect `_validationWarnings` from `configData` and return them in the `warnings` field, but `processMapeoSettingsFile` has no equivalent logic — its success return at line 701 never populates `warnings`. Any structural issues detected by `validateImportedConfig` inside `parseExtractedFiles` are logged internally but never reach the caller, so users importing `.settings` archives receive no indication that the archive may be malformed.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/importDropzone.ts
   Line: 700-709

   Comment:
   **Validation warnings silently dropped in Mapeo import path**

   `importConfigurationFile` was updated to collect `_validationWarnings` from `configData` and return them in the `warnings` field, but `processMapeoSettingsFile` has no equivalent logic — its success return at line 701 never populates `warnings`. Any structural issues detected by `validateImportedConfig` inside `parseExtractedFiles` are logged internally but never reach the caller, so users importing `.settings` archives receive no indication that the archive may be malformed.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `src/importDropzone.ts`, line 701-709 ([link](https://github.com/digidem/comapeo-category-spreadsheet-plugin/blob/6592ad14a22799a9b2b79907e2e6283e7d66cf1b/src/importDropzone.ts#L701-L709)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Validation warnings silently dropped on Mapeo import path**

   `processMapeoSettingsFile` now types `configData` as `ImportedConfig` (which carries `_validationWarnings`) and returns `ImportResult` (which has `warnings?: string[]`), but the success return at line 701 never reads `configData._validationWarnings`. Any structural issues caught by `validateImportedConfig` inside `parseExtractedFiles` are logged internally and then discarded — callers importing `.mapeosettings` archives receive no `warnings` payload and users see no indication the archive may be malformed. The parallel `.comapeocat` path in `importConfigurationFile` correctly collects these warnings into `allWarnings`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/importDropzone.ts
   Line: 701-709

   Comment:
   **Validation warnings silently dropped on Mapeo import path**

   `processMapeoSettingsFile` now types `configData` as `ImportedConfig` (which carries `_validationWarnings`) and returns `ImportResult` (which has `warnings?: string[]`), but the success return at line 701 never reads `configData._validationWarnings`. Any structural issues caught by `validateImportedConfig` inside `parseExtractedFiles` are logged internally and then discarded — callers importing `.mapeosettings` archives receive no `warnings` payload and users see no indication the archive may be malformed. The parallel `.comapeocat` path in `importConfigurationFile` correctly collects these warnings into `allWarnings`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (16): Last reviewed commit: ["fix: propagate \_validationWarnings in al..."](https://github.com/digidem/comapeo-category-spreadsheet-plugin/commit/c2c777b6ef0480c8522b9f441c8089987f22ecd6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35404203)</sub>

<!-- /greptile_comment -->