### PR TITLE
fix: preserve non-Latin scripts in select-option values and detail linting

### DIFF
--- a/src/builders/payloadBuilder.ts
+++ b/src/builders/payloadBuilder.ts
@@ -1251,7 +1251,14 @@ function buildTranslationsPayload(
           const value = o?.value || "";
           const label = o?.label || "";
           if (!label) return "";
-          return value === canonicalizeOptionValue(label) ? label : `${value}:${label}`;
+          // Mirror parseOptions' fallback: an emoji-/punctuation-only label
+          // canonicalizes to "", so parseOptions stores the raw label as
+          // value. Compare against that same fallback or bare options like
+          // "❤️" get misreconstructed as "❤️:❤️" and no longer match the
+          // source string in the translations sheet.
+          return value === (canonicalizeOptionValue(label) || label)
+            ? label
+            : `${value}:${label}`;
         })
         .filter(Boolean)
         .join(", ");

--- a/src/builders/payloadBuilder.ts
+++ b/src/builders/payloadBuilder.ts
@@ -391,7 +391,7 @@ function buildFields(data: SheetData): Field[] {
 /**
  * Parses comma-separated options string into SelectOption array
  * Supports two formats:
- * - "Label" -> {value: slugify(Label), label: Label}
+ * - "Label" -> {value: canonicalizeOptionValue(Label), label: Label}
  * - "value:Label" -> {value: value, label: Label}
  */
 function parseOptions(optionsStr: string): SelectOption[] | undefined {
@@ -411,9 +411,11 @@ function parseOptions(optionsStr: string): SelectOption[] | undefined {
       const label = opt.substring(colonIndex + 1);
       return { value, label };
     }
-    // Default format: just label
+    // Default format: just label. Fall back to the raw label when the
+    // canonical value is empty (emoji-/punctuation-only options) so distinct
+    // options never collapse to a single empty value and get deduplicated away.
     return {
-      value: slugify(opt),
+      value: canonicalizeOptionValue(opt) || opt,
       label: opt,
     };
   });
@@ -1249,7 +1251,7 @@ function buildTranslationsPayload(
           const value = o?.value || "";
           const label = o?.label || "";
           if (!label) return "";
-          return value === slugify(label) ? label : `${value}:${label}`;
+          return value === canonicalizeOptionValue(label) ? label : `${value}:${label}`;
         })
         .filter(Boolean)
         .join(", ");

--- a/src/importCategory/applyFields.ts
+++ b/src/importCategory/applyFields.ts
@@ -1,3 +1,5 @@
+/// <reference path="../utils.ts" />
+
 /**
  * Fields application functions for the import category functionality.
  * This file contains functions related to applying fields to the spreadsheet.
@@ -35,7 +37,17 @@ function applyFields(sheet: GoogleAppsScript.Spreadsheet.Sheet, fields: any[]) {
           // Handle both string and object formats
           if (typeof opt === "string") return opt;
           if (typeof opt === "object" && opt !== null) {
-            return opt.label || opt.value || opt.name || "";
+            const label = opt.label || opt.name || "";
+            const value = opt.value || "";
+            if (!label) return value;
+            // Preserve an explicit value that differs from the canonical label
+            // form by writing it back as "value:label". Otherwise a legacy
+            // config whose stored value predates canonicalizeOptionValue (e.g.
+            // diacritic-folded "cafe" for label "Café") would be re-written as
+            // the bare label and drift to "café" on the next export.
+            return value && value !== canonicalizeOptionValue(label)
+              ? `${value}:${label}`
+              : label;
           }
           return "";
         })

--- a/src/importCategory/applyFields.ts
+++ b/src/importCategory/applyFields.ts
@@ -44,8 +44,11 @@ function applyFields(sheet: GoogleAppsScript.Spreadsheet.Sheet, fields: any[]) {
             // form by writing it back as "value:label". Otherwise a legacy
             // config whose stored value predates canonicalizeOptionValue (e.g.
             // diacritic-folded "cafe" for label "Café") would be re-written as
-            // the bare label and drift to "café" on the next export.
-            return value && value !== canonicalizeOptionValue(label)
+            // the bare label and drift to "café" on the next export. Compare
+            // against the same "|| label" fallback parseOptions uses, or an
+            // emoji-/punctuation-only option like "❤️" (which canonicalizes
+            // to "") gets rewritten as "❤️:❤️" instead of staying bare.
+            return value && value !== (canonicalizeOptionValue(label) || label)
               ? `${value}:${label}`
               : label;
           }

--- a/src/importCategory/parseFiles.ts
+++ b/src/importCategory/parseFiles.ts
@@ -351,7 +351,7 @@ function parseExtractedFiles(
 									if (typeof opt === "string") {
 										return {
 											label: opt,
-											value: createOptionValue(opt, fieldId, optionIndex),
+											value: canonicalizeOptionValue(opt) || opt,
 										};
 									} else if (typeof opt === "object" && opt !== null) {
 										const obj = opt as Record<string, unknown>;
@@ -359,7 +359,7 @@ function parseExtractedFiles(
 										const normalizedValue =
 											typeof obj.value === "string" && obj.value.trim() !== ""
 												? obj.value
-											: createOptionValue(optionLabel, fieldId, optionIndex);
+											: canonicalizeOptionValue(optionLabel) || optionLabel;
 										return {
 											label: optionLabel,
 											value: normalizedValue,
@@ -368,7 +368,7 @@ function parseExtractedFiles(
 									const fallbackLabel = String(opt);
 									return {
 										label: fallbackLabel,
-										value: createOptionValue(fallbackLabel, fieldId, optionIndex),
+										value: canonicalizeOptionValue(fallbackLabel) || fallbackLabel,
 									};
 								});
 							} else if (typeof field.options === "object") {

--- a/src/lint/details.ts
+++ b/src/lint/details.ts
@@ -188,10 +188,18 @@ function checkUnreferencedDetails(): void {
       }
     }
 
-    // Check each detail to see if it's referenced by slugified name or explicit ID
+    // Check each detail against the category field tokens. Mirror the builder's
+    // resolution (payloadBuilder fieldNameToId): a category references a detail
+    // by NAME (exact or lowercase), falling back to the slugified name. So match
+    // on the detail's raw/lowercase name and slug, plus its explicit ID. The
+    // name check is essential for non-Latin names — slugify() returns "" for
+    // Thai etc., so without it every Thai detail referenced by name would be
+    // falsely reported as unreferenced.
     for (const entry of detailEntries) {
       const isReferenced =
         (entry.slug && referencedFields.has(entry.slug)) ||
+        referencedFields.has(entry.name) ||
+        referencedFields.has(entry.name.toLowerCase()) ||
         (entry.explicitId &&
           (referencedFields.has(entry.explicitId) ||
             referencedFields.has(entry.explicitId.toLowerCase())));

--- a/src/lint/shared.ts
+++ b/src/lint/shared.ts
@@ -57,7 +57,19 @@ function validateAndCapitalizeCommaList(value: string): string {
   if (!value || typeof value !== "string") return "";
   return value
     .split(",")
-    .map((item) => capitalizeFirstLetter(item.trim()))
+    .map((item) => {
+      const trimmed = item.trim();
+      // Options may use an explicit "value:label" form. Capitalizing the whole
+      // item would corrupt the value prefix (cafe:Café -> Cafe:Café), changing
+      // the stored value. Capitalize only the label; keep the value verbatim.
+      const colonIndex = trimmed.indexOf(":");
+      if (colonIndex > 0) {
+        const explicitValue = trimmed.slice(0, colonIndex);
+        const label = trimmed.slice(colonIndex + 1).trim();
+        return `${explicitValue}:${capitalizeFirstLetter(label)}`;
+      }
+      return capitalizeFirstLetter(trimmed);
+    })
     .filter((item) => item)
     .join(", ");
 }
@@ -614,6 +626,9 @@ function checkManualIdHygiene(
   const nameValues = sheet.getRange(2, 1, lastRow - 1, 1).getValues();
   const idRange = sheet.getRange(2, columnEIndex, lastRow - 1, 1);
   const idValues = idRange.getValues();
+  // Entity IDs must stay ASCII: the .comapeocat packager restricts them to
+  // ^[a-zA-Z0-9_-]+$ (package/src/writer.js), so a manually-entered non-ASCII
+  // ID would be rejected at build time. Warn on those here.
   const slugSafePattern = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 
   for (let i = 0; i < idValues.length; i++) {
@@ -630,16 +645,24 @@ function checkManualIdHygiene(
     // Skip if this row was already flagged as whitespace-only
     if (rawIds.has(row)) continue;
 
-    // Check slug-safety
+    // Check slug-safety. Non-ASCII explicit IDs are NOT blocked: the live
+    // build accepts them as entered and the schema allows free-string IDs, so
+    // users may keep meaningful non-Latin IDs (e.g. Thai). But warn that the
+    // standalone comapeocat CLI (package/src/writer.js SAFE_ID_REGEX) rejects
+    // them and the import reader cannot read back non-ASCII icon/translation
+    // entries — so round-trip and CLI builds are not guaranteed.
     if (!slugSafePattern.test(idValue)) {
       const cell = sheet.getRange(row, columnEIndex);
-      appendLintNote(
-        cell,
-        `Manual ID "${idValue}" is used as entered by the builder. Recommended format: lowercase letters, numbers, and hyphens (e.g., "my-category-id").`,
-        "warning",
-      );
+      // Only blame "non-ASCII" when that's actually true — the pattern also
+      // rejects pure-ASCII input (uppercase, spaces, underscores, double
+      // hyphens), where the CLI/round-trip caveat below does not apply.
+      const isNonAscii = /[^\x00-\x7F]/.test(idValue);
+      const message = isNonAscii
+        ? `Manual ID "${idValue}" contains non-ASCII characters. The live build accepts it as entered, but the standalone comapeocat CLI rejects such IDs and import cannot read back non-ASCII icon/translation entries. For full toolchain compatibility use lowercase ASCII letters, numbers, and hyphens (e.g., "my-category-id").`
+        : `Manual ID "${idValue}" is used as entered by the builder. Recommended format: lowercase letters, numbers, and hyphens (e.g., "my-category-id").`;
+      appendLintNote(cell, message, "warning");
       logger.warn(
-        `${sheetName} row ${row}: non-slug-safe ID "${idValue}"`,
+        `${sheetName} row ${row}: ${isNonAscii ? "non-ASCII" : "non-slug-safe"} ID "${idValue}"`,
       );
     }
   }
@@ -766,8 +789,11 @@ function parseCanonicalOptions(optionsStr: string): Array<{
       const label = opt.substring(colonIndex + 1);
       return { value, label, raw: opt };
     }
+    // Mirror the builder: fall back to the raw label when the canonical value
+    // is empty (emoji-/punctuation-only options) so distinct options never
+    // collapse to one empty value. Kept in lockstep with parseOptions().
     return {
-      value: slugify(opt),
+      value: canonicalizeOptionValue(opt) || opt,
       label: opt,
       raw: opt,
     };

--- a/src/lint/strictMetrics.ts
+++ b/src/lint/strictMetrics.ts
@@ -215,7 +215,7 @@ function buildLintTranslationsByLocale(
         if (!label) {
           return "";
         }
-        return value === slugify(label) ? label : `${value}:${label}`;
+        return value === canonicalizeOptionValue(label) ? label : `${value}:${label}`;
       })
       .filter(Boolean)
       .join(", ");

--- a/src/lint/strictMetrics.ts
+++ b/src/lint/strictMetrics.ts
@@ -215,7 +215,13 @@ function buildLintTranslationsByLocale(
         if (!label) {
           return "";
         }
-        return value === canonicalizeOptionValue(label) ? label : `${value}:${label}`;
+        // Mirror parseOptions' fallback (value = canonicalizeOptionValue(opt)
+        // || opt): an emoji-/punctuation-only label canonicalizes to "", so
+        // compare against that same fallback or the reconstruction drifts to
+        // "label:label" and no longer matches the spreadsheet source string.
+        return value === (canonicalizeOptionValue(label) || label)
+          ? label
+          : `${value}:${label}`;
       })
       .filter(Boolean)
       .join(", ");

--- a/src/test/testUtilsSlugify.ts
+++ b/src/test/testUtilsSlugify.ts
@@ -352,10 +352,44 @@ function testUtilsSlugify(): void {
     assertEqual(slugify("\t\n\r"), "", "Should handle various whitespace characters");
   });
 
-  // Test 37: Complex unicode characters
+  // Test 37: Complex unicode characters (slugify is ASCII-only for entity IDs)
   runTest("Edge case: Complex unicode characters", () => {
-    assertEqual(slugify("日本語"), "", "Should remove complex unicode");
+    assertEqual(slugify("日本語"), "", "slugify is ASCII-only; non-Latin entity names fold to empty and fall back to prefix-N");
     assertEqual(slugify("Emoji's 🚀🎉"), "emojis", "Should remove emojis and handle apostrophes");
+  });
+
+  // Test 37b: canonicalizeOptionValue — select option values preserve EVERY
+  // script. Regression: option values used to be slugify()'d (ASCII-only), so
+  // all-Thai / all-Vietnamese / all-Cyrillic / all-Greek option lists collapsed
+  // to one value and the linter deleted the "duplicates".
+  runTest("canonicalizeOptionValue: preserves all scripts (no false duplicates)", () => {
+    // Thai: distinct options stay distinct, combining marks intact.
+    const thaiA = canonicalizeOptionValue("เห็นด้วยตา");
+    const thaiB = canonicalizeOptionValue("ได้ยินเสียงร้อง");
+    assertTrue(thaiA.length > 0, "Thai option value must not be empty");
+    assertTrue(thaiB.length > 0, "Thai option value must not be empty");
+    assertTrue(thaiA !== thaiB, "Distinct Thai options must not collide");
+    assertEqual(canonicalizeOptionValue("เห็นด้วยตา"), "เห็นด้วยตา", "Thai combining marks must be preserved");
+    assertEqual(canonicalizeOptionValue("ไม้ตอง (ทองหลาง)"), "ไม้ตอง-ทองหลาง", "Thai punctuation becomes a separator, script intact");
+
+    // Vietnamese tones are semantic — must NOT collapse (slugify gave "ma" for all).
+    const vn = ["má", "mà", "mả", "mã", "mạ"].map(canonicalizeOptionValue);
+    assertEqual(new Set(vn).size, 5, "Vietnamese tone variants must stay distinct");
+
+    // Cyrillic й ≠ и and Greek ά ≠ α (slugify collapsed both pairs).
+    assertTrue(canonicalizeOptionValue("й") !== canonicalizeOptionValue("и"), "Cyrillic й and и must stay distinct");
+    assertTrue(canonicalizeOptionValue("ά") !== canonicalizeOptionValue("α"), "Greek ά and α must stay distinct");
+
+    // Diacritics preserved (unlike slugify's Café -> cafe).
+    assertEqual(canonicalizeOptionValue("Café"), "café", "Diacritics are semantic and must be kept");
+
+    // Emoji variation selectors must not leave an invisible colliding mark.
+    assertEqual(canonicalizeOptionValue("❤️"), "", "Emoji-only option reduces to empty (falls back), not an invisible mark");
+    assertTrue(canonicalizeOptionValue("❤️") !== canonicalizeOptionValue("☕️") || canonicalizeOptionValue("❤️") === "", "No invisible cross-emoji collision");
+
+    // Empty / separator-only input.
+    assertEqual(canonicalizeOptionValue(""), "", "Empty input -> empty value");
+    assertEqual(canonicalizeOptionValue("   "), "", "Whitespace-only -> empty value");
   });
 
   // Test 38: Performance - many slugs

--- a/src/test/testUtilsSlugify.ts
+++ b/src/test/testUtilsSlugify.ts
@@ -385,7 +385,13 @@ function testUtilsSlugify(): void {
 
     // Emoji variation selectors must not leave an invisible colliding mark.
     assertEqual(canonicalizeOptionValue("❤️"), "", "Emoji-only option reduces to empty (falls back), not an invisible mark");
-    assertTrue(canonicalizeOptionValue("❤️") !== canonicalizeOptionValue("☕️") || canonicalizeOptionValue("❤️") === "", "No invisible cross-emoji collision");
+    assertEqual(canonicalizeOptionValue("☕️"), "", "Coffee emoji also reduces to empty (shares the same fallback path)");
+    // Both canonicalize to "", but callers use `canonicalizeOptionValue(x) || x`
+    // — verify that fallback actually keeps distinct emoji options distinct,
+    // since two different options both mapping to "" would otherwise collide.
+    const heartValue = canonicalizeOptionValue("❤️") || "❤️";
+    const coffeeValue = canonicalizeOptionValue("☕️") || "☕️";
+    assertTrue(heartValue !== coffeeValue, "Distinct emoji options must stay distinct via the raw-label fallback");
 
     // Empty / separator-only input.
     assertEqual(canonicalizeOptionValue(""), "", "Empty input -> empty value");

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,7 +49,13 @@ const ALL_LANGUAGES: Record<string, string> = {
 };
 
 /**
- * Converts a string to a slug format.
+ * Converts a string to an ASCII slug format. Used for ENTITY identifiers
+ * (field IDs, category/preset IDs, icon IDs, config name) which the
+ * `.comapeocat` packager restricts to `^[a-zA-Z0-9_-]+$` (see
+ * package/src/writer.js SAFE_ID_REGEX). Non-Latin names fold to "" here and
+ * callers fall back to `prefix-N` — that is intentional. Do NOT use this for
+ * select option values; use canonicalizeOptionValue() instead, which preserves
+ * every script.
  * @param input The input string to be converted.
  * @returns The slugified string.
  */
@@ -65,9 +71,57 @@ function slugify(input: string | any): string {
   return normalized
     .toLocaleLowerCase("en-US")  // Use en-US locale to avoid Turkish 'I' → 'ı' issue
     .trim()
-    .replace(/[^\w\s-]/g, "")    // Remove non-word characters (keep letters, numbers, underscore, whitespace, hyphen)
+    .replace(/[^\w\s-]/g, "")    // Remove non-word characters (keep ASCII letters, numbers, underscore, whitespace, hyphen)
     .replace(/[\s_-]+/g, "-")    // Replace whitespace/underscore/hyphen sequences with single hyphen
     .replace(/^-+|-+$/g, "");    // Remove leading/trailing hyphens
+}
+
+/**
+ * Canonicalizes a select-option label into its stored machine value while
+ * preserving EVERY script (Thai, Vietnamese, Cyrillic, Greek, CJK, ...).
+ *
+ * Unlike slugify() — which is ASCII-only and folds diacritics for entity IDs —
+ * this keeps Unicode letters and combining marks intact so distinct options
+ * never collapse to the same value. Collapsing is what caused the linter to
+ * flag and delete all-Thai (and all-Vietnamese/Cyrillic/Greek) option lists as
+ * "duplicates". Diacritics are semantic in tone languages (má ≠ mà), so they
+ * are preserved rather than stripped.
+ *
+ * Used in lockstep by the builder (parseOptions) and the linter
+ * (parseCanonicalOptions) so generation and validation agree.
+ *
+ * @param input Raw option label from the spreadsheet.
+ * @returns A Unicode-safe canonical value ("" if nothing usable remains —
+ *   e.g. emoji- or punctuation-only input). Callers fall back to the raw
+ *   label in that case so distinct options never collapse to one empty value.
+ */
+function canonicalizeOptionValue(input: string | any): string {
+  if (!input) return "";
+
+  const str = typeof input === "string" ? input : String(input);
+
+  return (
+    str
+      // Composed form so a base + combining mark compares equal to its
+      // precomposed code point (Thai is NFC-stable; this normalizes the rest).
+      .normalize("NFC")
+      // Drop variation selectors (emoji presentation hints). Without this,
+      // "❤️" and "☕️" both reduce to a lone invisible U+FE0F and collide.
+      .replace(/[\u{FE00}-\u{FE0F}]/gu, "")
+      .toLocaleLowerCase("en-US") // en-US avoids the Turkish 'I' → 'ı' issue
+      .trim()
+      // Remove orphan combining marks — a mark run with NO base, i.e. at the
+      // start or preceded by a non-letter/number/mark (space, punctuation).
+      // The boundary class excludes \p{M} on purpose: a mark preceded by another
+      // mark is part of the same cluster (Thai vowel + tone) and must be kept.
+      .replace(/(^|[^\p{L}\p{N}\p{M}])(\p{M}+)/gu, "$1")
+      // Keep letters, (attached) marks, and numbers from any script; preserve
+      // diacritics. Whitespace/underscore/hyphen are kept as separators; every
+      // other symbol/punctuation mark is removed.
+      .replace(/[^\p{L}\p{M}\p{N}\s_-]/gu, "")
+      .replace(/[\s_-]+/g, "-") // collapse separator runs to a single hyphen
+      .replace(/^-+|-+$/g, "")
+  ); // trim leading/trailing hyphens
 }
 
 function sanitizeIconSlug(slug: string | null | undefined): string {

--- a/src/version.ts
+++ b/src/version.ts
@@ -7,11 +7,11 @@
  */
 
 const versionData = {
-  "version": "2.0.0+e8105ab",
-  "commit": "e8105ab",
+  "version": "2.0.0+0f61d3f",
+  "commit": "0f61d3f",
   "branch": "fix/unicode-option-values-and-lint-fixes",
-  "isDirty": true,
-  "buildDate": "2026-07-23T00:39:36.796Z"
+  "isDirty": false,
+  "buildDate": "2026-07-23T10:29:09.943Z"
 };
 
 export function getVersionInfo(): string {

--- a/src/version.ts
+++ b/src/version.ts
@@ -7,11 +7,11 @@
  */
 
 const versionData = {
-  "version": "2.0.0+23988c7",
-  "commit": "23988c7",
-  "branch": "refactor/34-split-lint-modules",
-  "isDirty": false,
-  "buildDate": "2026-07-22T19:17:53.108Z"
+  "version": "2.0.0+ee65598",
+  "commit": "ee65598",
+  "branch": "chore/geometry-cleanup-and-regression-sanitizer-fix",
+  "isDirty": true,
+  "buildDate": "2026-07-23T00:01:05.721Z"
 };
 
 export function getVersionInfo(): string {

--- a/src/version.ts
+++ b/src/version.ts
@@ -7,11 +7,11 @@
  */
 
 const versionData = {
-  "version": "2.0.0+ee65598",
-  "commit": "ee65598",
-  "branch": "chore/geometry-cleanup-and-regression-sanitizer-fix",
+  "version": "2.0.0+e8105ab",
+  "commit": "e8105ab",
+  "branch": "fix/unicode-option-values-and-lint-fixes",
   "isDirty": true,
-  "buildDate": "2026-07-23T00:01:05.721Z"
+  "buildDate": "2026-07-23T00:39:36.796Z"
 };
 
 export function getVersionInfo(): string {


### PR DESCRIPTION
## Summary

Two related bugs found while working on Thai/non-Latin-script support: select-option machine values and the "unreferenced detail" linter both relied on `slugify()`, which is ASCII-only.

## The bugs

1. **Option values collapsed for non-Latin scripts.** `parseOptions`/`parseCanonicalOptions` derived a select option's stored `value` from `slugify(label)`. For all-Thai / all-Vietnamese / all-Cyrillic / all-Greek option lists, every label slugified to `""` (or to the same collapsed string), so distinct options collided and the linter flagged/deleted the "duplicates". Diacritics (`Café`) and tone marks (`má` vs `mà`) were also stripped even though they're semantically distinct in those languages.
2. **False "unreferenced detail" warnings for non-Latin field names.** `checkUnreferencedDetails` only matched a detail against a category's Fields column via `slugify(token)`. The builder (`payloadBuilder.ts` `fieldNameToId`) actually resolves references by exact/lowercase **name** first, falling back to slug — the linter didn't mirror that, so every non-Latin-named detail (e.g. Thai) was falsely reported as unreferenced.

## The fix

- Add `canonicalizeOptionValue()` (`utils.ts`): a Unicode-safe canonicalizer for option values that keeps letters/marks/numbers from any script (only strips variation selectors and orphan combining marks), unlike `slugify()` which stays ASCII-only for entity IDs (`.comapeocat` packager restricts those to `^[a-zA-Z0-9_-]+$`). Falls back to the raw label when nothing usable remains (emoji-/punctuation-only options).
- Wire it into the builder (`payloadBuilder.ts`), the linter (`lint/shared.ts`, `lint/strictMetrics.ts`), and import (`applyFields.ts`) so generation, validation, and round-trip all agree.
- `validateAndCapitalizeCommaList` now capitalizes only the label half of an explicit `value:label` option instead of corrupting the value prefix.
- `checkManualIdHygiene`'s warning text now only claims "non-ASCII" when the ID actually is — the slug-safety regex also rejects plain-ASCII input (uppercase, spaces, underscores), which was getting the same misleading message.
- `checkUnreferencedDetails` now matches a detail's raw/lowercase **name** (in addition to slug and explicit ID), mirroring the builder's actual resolution order.
- Adds regression tests for Thai, Vietnamese, Cyrillic, Greek, and emoji-only option values.

## Verification

- `bunx tsc --noEmit` — clean
- `bunx biome lint .` — clean
- Manually re-derived `canonicalizeOptionValue()` in Node against every assertion in the new test to confirm behavior (Thai/Vietnamese/Cyrillic/Greek stay distinct, diacritics preserved, emoji-only → falls back to raw label).

## Note

This branch was rebuilt from a clean `main` base after an earlier push accidentally landed these commits on PR #51's branch, which explicitly scoped them out. That mistake was corrected before opening this PR.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR preserves non-Latin select-option values and aligns lint/import behavior around the same canonical form. The main changes are:

- Adds `canonicalizeOptionValue()` for Unicode-safe option machine values.
- Uses the new option canonicalization in build, import, lint parsing, and lint metrics paths.
- Matches unreferenced details by raw and lowercase names as well as slug/explicit ID.
- Keeps explicit `value:label` option prefixes unchanged during label capitalization.
- Adds tests for Thai, Vietnamese, Cyrillic, Greek, diacritics, and emoji-only option fallback.
- Regenerates `src/version.ts` metadata for the current branch.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

The changed build, import, lint, and translation paths now share the same Unicode option canonicalization and raw-label fallback behavior. Prior emoji fallback drift cases are addressed in the updated reconstruction code. No blocking correctness or security issues were found.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the Unicode preservation harness to validate Thai distinctness, Vietnamese tone distinctness, Cyrillic and Greek distinctness, diacritic preservation, emoji raw-label fallback through parseOptions, and explicit value:label capitalization preservation.
- Verified that Typecheck exited with status 0.
- Verified that Biome lint exited with status 0.

<a href="https://app.greptile.com/trex/runs/15558031/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/utils.ts | Documents ASCII-only slug behavior and adds Unicode-preserving canonicalizeOptionValue for select option machine values. |
| src/builders/payloadBuilder.ts | Swaps select option default values to Unicode-safe canonicalization and keeps translation-source reconstruction aligned with emoji fallback. |
| src/importCategory/applyFields.ts | Preserves explicit imported option values and writes bare labels only when stored values match canonical label fallback. |
| src/importCategory/parseFiles.ts | Normalizes missing imported option values with Unicode-safe canonicalization instead of ASCII slug fallbacks. |
| src/lint/shared.ts | Keeps explicit option value prefixes unchanged during label capitalization and aligns canonical option parsing/manual ID messages. |
| src/lint/details.ts | Updates unreferenced-detail detection to match raw and lowercase detail names in addition to slug/explicit IDs. |
| src/lint/strictMetrics.ts | Aligns lint translation option-string reconstruction with the builder’s Unicode canonicalization and raw-label fallback. |
| src/test/testUtilsSlugify.ts | Adds regression coverage for Unicode option canonicalization across Thai, Vietnamese, Cyrillic, Greek, diacritics, and emoji fallback. |
| src/version.ts | Regenerates version metadata for the current branch with a clean build marker. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
participant Sheet as Spreadsheet Details/Categories
participant Builder as payloadBuilder.parseOptions
participant Canon as canonicalizeOptionValue
participant Lint as lint shared/details/metrics
participant Import as importCategory apply/parse
Sheet->>Builder: option label or value:label
Builder->>Canon: bare option label
Canon-->>Builder: Unicode value or empty
Builder-->>Builder: fallback to raw label when empty
Sheet->>Lint: fields/options/detail references
Lint->>Canon: parseCanonicalOptions and option matching
Lint-->>Sheet: warnings only when canonical/raw-name checks fail
Import->>Canon: imported option labels missing explicit value
Import-->>Sheet: bare label or explicit value:label preserving value
```

<sub>Reviews (4): Last reviewed commit: ["test: replace tautological emoji-collisi..."](https://github.com/digidem/comapeo-category-spreadsheet-plugin/commit/6a1adf479e220ae3688648dd90aff5a376ef6aab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46520544)</sub>

<!-- /greptile_comment -->